### PR TITLE
處理 Transfer-Encoding 未被parse的資料(bytes parser)

### DIFF
--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -273,6 +273,7 @@ class WebApHelper {
       var query = await apQuery(
         "ag222",
         {"arg01": years, "arg02": semesterValue},
+        bytesResponse: true,
       );
       return CourseData.fromJson(coursetableParser(query.data));
     }
@@ -281,6 +282,7 @@ class WebApHelper {
       {"arg01": years, "arg02": semesterValue},
       cacheKey: "${coursetableCacheKey}_${years}_${semesterValue}",
       cacheExpiredTime: Duration(hours: 6),
+      bytesResponse: true,
     );
     var parsedData = coursetableParser(query.data);
     if (parsedData["courses"].length == 0) {
@@ -335,6 +337,7 @@ class WebApHelper {
     var query = await apQuery(
       "ag302_02",
       {"room_id": roomId, "yms_yms": "${years}#${semesterValue}"},
+      bytesResponse: true,
     );
 
     return CourseData.fromJson(

--- a/lib/api/parser/ap_parser.dart
+++ b/lib/api/parser/ap_parser.dart
@@ -56,6 +56,9 @@ int apLoginParser(dynamic html) {
     2 : Relogin
     3 : Not found login message
     */
+  if (html is Uint8List) {
+    html = clearTransEncoding(html);
+  }
   if (html.indexOf("top.location.href='f_index.html'") > -1) {
     return 0;
   }
@@ -178,8 +181,10 @@ Map<String, dynamic> scoresParser(String html) {
   return data;
 }
 
-Map<String, dynamic> coursetableParser(String html) {
-  html = clearHtml(html);
+Map<String, dynamic> coursetableParser(dynamic html) {
+  if (html is Uint8List) {
+    html = clearTransEncoding(html);
+  }
 
   Map<String, dynamic> data = {
     "courses": [],
@@ -381,8 +386,10 @@ Map<String, dynamic> roomListParser(String html) {
   return data;
 }
 
-Map<String, dynamic> roomCourseTableQueryParser(String html) {
-  html = clearHtml(html);
+Map<String, dynamic> roomCourseTableQueryParser(dynamic html) {
+  if (html is Uint8List) {
+    html = clearTransEncoding(html);
+  }
 
   Map<String, dynamic> data = {
     "courses": [],

--- a/lib/api/parser/ap_parser.dart
+++ b/lib/api/parser/ap_parser.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:html/parser.dart' show parse;
 
 String clearHtml(String html) {
@@ -10,7 +12,43 @@ String clearHtml(String html) {
   return temp.replaceAll(new RegExp(r"\r\n(\w{1,4})\r\n"), "");
 }
 
-int apLoginParser(String html) {
+String clearTransEncoding(List<int> htmlBytes) {
+  // htmlBytes is fixed-length list, need copy.
+  var tempData = new List<int>.from(htmlBytes);
+
+  //Add /r/n on first word.
+  tempData.insert(0, 10);
+  tempData.insert(0, 13);
+
+  int startIndex = 0;
+  for (int i = 0; i < tempData.length - 1; i++) {
+    //check i and i+1 is /r/n
+    if (tempData[i] == 13 && tempData[i + 1] == 10) {
+      if (i - startIndex - 2 <= 4 && i - startIndex - 2 > 0) {
+        //check in this range word is number or A~F (Hex)
+        int removeCount = 0;
+        for (int _strIndex = startIndex + 2; _strIndex < i; _strIndex++) {
+          if ((tempData[_strIndex] > 47 && tempData[_strIndex] < 58) ||
+              (tempData[_strIndex] > 64 && tempData[_strIndex] < 71) ||
+              (tempData[_strIndex] > 96 && tempData[_strIndex] < 103)) {
+            removeCount++;
+          }
+        }
+        if (removeCount == i - startIndex - 2) {
+          tempData.removeRange(startIndex, i + 2);
+        }
+        //Subtract offset
+        i -= i - startIndex - 2;
+        startIndex -= i - startIndex - 2;
+      }
+      startIndex = i;
+    }
+  }
+
+  return utf8.decode(tempData, allowMalformed: true);
+}
+
+int apLoginParser(dynamic html) {
   /*
     Retrun type Int
     0 : Login Success

--- a/lib/api/parser/ap_parser.dart
+++ b/lib/api/parser/ap_parser.dart
@@ -3,15 +3,6 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:html/parser.dart' show parse;
 
-String clearHtml(String html) {
-  String temp = "";
-  for (int i = 0; i < html.length; i++) {
-    if (html.codeUnitAt(i) > 40000) continue;
-    temp += html[i];
-  }
-  return temp.replaceAll(new RegExp(r"\r\n(\w{1,4})\r\n"), "");
-}
-
 String clearTransEncoding(List<int> htmlBytes) {
   // htmlBytes is fixed-length list, need copy.
   var tempData = new List<int>.from(htmlBytes);


### PR DESCRIPTION
類似於 #134 

*  移除了 #134 的regex parser
* apQuery增加bytes response的選項
* 增加一個bytes parser

測試並不影響Cache

目前僅在course table 跟 apLoginParser(判斷重登狀態) 有加入parser
但Transfer-Encoding 沒有被parse的問題在整個Ap底下都會發生
目前看起來影響比較嚴重的只有課表部分
