### PR TITLE
加入 API 抽象層

### DIFF
--- a/lib/api/interface/bus_interface.dart
+++ b/lib/api/interface/bus_interface.dart
@@ -6,7 +6,9 @@ import 'package:nkust_ap/models/bus_violation_records_data.dart';
 import 'package:nkust_ap/models/cancel_bus_data.dart';
 
 abstract class BusInterface {
-  Future<GeneralResponse> login();
+  Future<GeneralResponse> login({String username, String password});
+
+  Future<GeneralResponse> logout();
 
   Future<BusData> getTimeTable(
       {DateTime fromDateTime, String year, String month, String day});

--- a/lib/api/interface/bus_interface.dart
+++ b/lib/api/interface/bus_interface.dart
@@ -1,0 +1,21 @@
+import 'package:nkust_ap/api/helper.dart';
+import 'package:nkust_ap/models/booking_bus_data.dart';
+import 'package:nkust_ap/models/bus_data.dart';
+import 'package:nkust_ap/models/bus_reservations_data.dart';
+import 'package:nkust_ap/models/bus_violation_records_data.dart';
+import 'package:nkust_ap/models/cancel_bus_data.dart';
+
+abstract class BusInterface {
+  Future<GeneralResponse> login();
+
+  Future<BusData> getTimeTable(
+      {DateTime fromDateTime, String year, String month, String day});
+
+  Future<BookingBusData> bookBus({String busId});
+
+  Future<CancelBusData> cancelBusReservation({String busId});
+
+  Future<BusReservationsData> getBusReservations();
+
+  Future<BusViolationRecordsData> getBusViolationRecords();
+}

--- a/lib/api/interface/leave_interface.dart
+++ b/lib/api/interface/leave_interface.dart
@@ -5,7 +5,9 @@ import 'package:nkust_ap/models/leave_submit_data.dart';
 import 'package:nkust_ap/models/leave_submit_info_data.dart';
 
 abstract class LeaveInterface {
-  Future<GeneralResponse> login();
+  Future<GeneralResponse> login({String username, String password});
+
+  Future<GeneralResponse> logout();
 
   Future<LeaveData> getLeaves({String year, String value});
 

--- a/lib/api/interface/leave_interface.dart
+++ b/lib/api/interface/leave_interface.dart
@@ -1,0 +1,16 @@
+import 'package:image_picker/image_picker.dart';
+import 'package:nkust_ap/api/helper.dart';
+import 'package:nkust_ap/models/leave_data.dart';
+import 'package:nkust_ap/models/leave_submit_data.dart';
+import 'package:nkust_ap/models/leave_submit_info_data.dart';
+
+abstract class WebApInterface {
+  Future<GeneralResponse> login();
+
+  Future<LeaveData> getLeaves({String year, String value});
+
+  Future<LeaveSubmitInfoData> getLeavesSubmitInfo();
+
+  Future<GeneralResponse> leavesSubmit(LeaveSubmitData data,
+      {PickedFile proofImage});
+}

--- a/lib/api/interface/leave_interface.dart
+++ b/lib/api/interface/leave_interface.dart
@@ -4,7 +4,7 @@ import 'package:nkust_ap/models/leave_data.dart';
 import 'package:nkust_ap/models/leave_submit_data.dart';
 import 'package:nkust_ap/models/leave_submit_info_data.dart';
 
-abstract class WebApInterface {
+abstract class LeaveInterface {
   Future<GeneralResponse> login();
 
   Future<LeaveData> getLeaves({String year, String value});

--- a/lib/api/interface/webap_interface.dart
+++ b/lib/api/interface/webap_interface.dart
@@ -1,0 +1,25 @@
+import 'package:ap_common/models/semester_data.dart';
+import 'package:ap_common/models/user_info.dart';
+import 'package:ap_common/models/score_data.dart';
+import 'package:ap_common/models/course_data.dart';
+import 'package:nkust_ap/models/midterm_alerts_data.dart';
+import 'package:nkust_ap/models/room_data.dart';
+
+abstract class WebApInterface {
+  Future<void> logout();
+
+  Future<UserInfo> getUserInfo();
+
+  Future<SemesterData> getSemesters();
+
+  Future<ScoreData> getScores({String year, String value});
+
+  Future<CourseData> getCourseTable({String year, String value});
+
+  Future<MidtermAlertsData> getMidtermAlerts({String year, String value});
+
+  Future<RoomData> roomList({String campusAreaId});
+
+  Future<CourseData> getRoomCourseTable(
+      {String roomId, String year, String value});
+}

--- a/lib/api/interface/webap_interface.dart
+++ b/lib/api/interface/webap_interface.dart
@@ -1,3 +1,4 @@
+import 'package:ap_common/models/general_response.dart';
 import 'package:ap_common/models/semester_data.dart';
 import 'package:ap_common/models/user_info.dart';
 import 'package:ap_common/models/score_data.dart';
@@ -6,7 +7,9 @@ import 'package:nkust_ap/models/midterm_alerts_data.dart';
 import 'package:nkust_ap/models/room_data.dart';
 
 abstract class WebApInterface {
-  Future<void> logout();
+  Future<GeneralResponse> login({String username, String password});
+
+  Future<GeneralResponse> logout();
 
   Future<UserInfo> getUserInfo();
 


### PR DESCRIPTION
定義三大系統
 - 校務
 - 校車
 - 缺曠

透過不同方法的實作  
可在 `Helper` 做邏輯切換  
若功能重複也是可行
可參考範例
```dart
class BlackMagicHelper implements WebApInterface, BusInterface{
  ....
}
```
@takidog  想確認API命名與參數是否正確