### PR TITLE
修復請假系統登入失敗問題 

### DIFF
--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -147,6 +147,7 @@ class WebApHelper {
           message: "Login exceeded retry limit");
     }
     await checkLogin();
+    await apQuery("ag304_01", null);
 
     Response res = await dio.post(
       "https://webap.nkust.edu.tw/nkust/fnc.jsp",


### PR DESCRIPTION
#193 

沒有使用過webap功能直接去使用`fnc.jsp`
會直接被導向到登入頁

在登入leave時去請求`ag304_01` (學期列表)
來避免問題
