### PR TITLE
修復parser在請假頁面執行時間過長問題

### DIFF
--- a/lib/api/leave_helper.dart
+++ b/lib/api/leave_helper.dart
@@ -261,7 +261,7 @@ class LeaveHelper {
     );
     String fakeDate =
         "${DateTime.now().year - 1911}/${DateTime.now().month}/${DateTime.now().day}";
-    requestData = hiddenInputGet(res.data);
+    requestData = hiddenInputGet(res.data, removeTdElement: true);
     requestData[r"ctl00$ContentPlaceHolder1$CK001$DateUCCBegin$text1"] =
         fakeDate;
     requestData[r"ctl00$ContentPlaceHolder1$CK001$DateUCCEnd$text1"] = fakeDate;

--- a/lib/api/parser/leave_parser.dart
+++ b/lib/api/parser/leave_parser.dart
@@ -1,6 +1,18 @@
 import 'package:html/parser.dart' show parse;
 
-Map<String, dynamic> hiddenInputGet(String html) {
+Map<String, dynamic> hiddenInputGet(String html, {bool removeTdElement}) {
+  if (removeTdElement == true) {
+    String firstMatchString = '<td width="40px" nowrap="nowrap" align="left">';
+    String lastMatchString = '</td>';
+    var startIndex = html.indexOf(firstMatchString);
+    while (startIndex > -1) {
+      html = html.substring(0, startIndex) +
+          html.substring(html.indexOf(lastMatchString, startIndex) +
+              lastMatchString.length);
+      startIndex = html.indexOf(firstMatchString);
+    }
+  }
+
   var document = parse(html);
   Map<String, dynamic> hiddenData = {};
   var inputDom = document.getElementsByTagName("input");


### PR DESCRIPTION
如題 
#195 

移除造成問題的字串

在Dart console 執行`parse` 從41s降到0.6s