### PR TITLE
fix: incorrect handling of uint8list argument

### DIFF
--- a/lib/api/parser/ap_parser.dart
+++ b/lib/api/parser/ap_parser.dart
@@ -68,11 +68,14 @@ class WebApParser {
     4 : Not found error message
     500 : server busy
     */
-    String rawHtml;
+    String? rawHtml;
     if (html is Uint8List) {
       rawHtml = clearTransEncoding(html);
-    } else if (html is String) {
+    }
+    if (html is String) {
       rawHtml = html;
+    }
+    if (rawHtml != null) {
       if (rawHtml.contains('onclick="go_change()')) {
         return 4;
       }


### PR DESCRIPTION
Fixed the issue that apLoginParser handled uint8list incorrectly.
確保其正確parse html並回傳statusCode

#264 中提到的課表瞬間載入失敗問題可以透過此修改來避免
(此修改促使取得內容失敗時的retry流程順暢)

由於是關鍵組件
尚須測試對於其他功能有無造成問題