### PR TITLE
feat(ci): LLM-based bilingual changelog via PR comments + workflow path filters

### DIFF
--- a/.github/scripts/aggregate_changelog.sh
+++ b/.github/scripts/aggregate_changelog.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# aggregate_changelog.sh <beta|stable> <output_file>
+#
+# Queries GitHub API for merged PRs since last release and aggregates
+# bilingual changelog entries from PR comments.
+#
+# Output format: JSON array of {"zh-TW": "...", "en-US": "..."}
+
+set -euo pipefail
+
+RELEASE_TYPE="${1:-beta}"
+OUTPUT_FILE="${2:-changelog_aggregated.json}"
+
+# Find last release tag by type
+if [ "$RELEASE_TYPE" = "stable" ]; then
+  LAST_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""')
+else
+  LAST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+fi
+
+if [ -n "$LAST_TAG" ]; then
+  LAST_DATE=$(gh release view "$LAST_TAG" --json publishedAt --jq '.publishedAt')
+  echo "Aggregating changelog since: $LAST_TAG ($LAST_DATE)"
+else
+  LAST_DATE="1970-01-01T00:00:00Z"
+  echo "No previous release found, aggregating all entries"
+fi
+
+# Get merged PRs to develop since last release (newest first)
+PRS=$(gh pr list \
+  --base develop \
+  --state merged \
+  --limit 100 \
+  --json number,mergedAt \
+  --jq "[.[] | select(.mergedAt > \"$LAST_DATE\") | .number]")
+
+PR_COUNT=$(echo "$PRS" | jq length)
+echo "Found $PR_COUNT merged PR(s)"
+
+ENTRIES="[]"
+
+for PR_NUM in $(echo "$PRS" | jq -r '.[]'); do
+  # Find the last changelog-entry comment on this PR
+  COMMENT=$(gh api "repos/$GITHUB_REPOSITORY/issues/${PR_NUM}/comments" \
+    --jq '[.[] | select(.body | startswith("<!-- changelog-entry")) | .body] | last // ""')
+
+  if [ -z "$COMMENT" ] || [ "$COMMENT" = "null" ]; then
+    echo "PR #$PR_NUM: no changelog comment, skipping"
+    continue
+  fi
+
+  # Extract JSON from between the comment markers (expects single-line JSON)
+  ENTRY=$(echo "$COMMENT" | awk '/<!-- changelog-entry/{found=1;next}/-->/{found=0}found' | head -1 | xargs)
+
+  if echo "$ENTRY" | jq -e '.["zh-TW"] and .["en-US"]' > /dev/null 2>&1; then
+    ENTRIES=$(echo "$ENTRIES" | jq ". + [$ENTRY]")
+    echo "PR #$PR_NUM: added — $(echo "$ENTRY" | jq -r '.["en-US"]')"
+  else
+    echo "PR #$PR_NUM: malformed changelog JSON, skipping"
+  fi
+done
+
+echo "$ENTRIES" > "$OUTPUT_FILE"
+echo "Aggregated $(echo "$ENTRIES" | jq length) entries → $OUTPUT_FILE"

--- a/.github/scripts/generate_changelog.sh
+++ b/.github/scripts/generate_changelog.sh
@@ -5,9 +5,78 @@ VERSION_CODE="$1"
 TARGET="$2" # android, ios, macos, or github
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# New path: use LLM-aggregated changelog if AGGREGATED_CHANGELOG is set
+# ---------------------------------------------------------------------------
+if [ -n "${AGGREGATED_CHANGELOG:-}" ] && [ -f "$AGGREGATED_CHANGELOG" ]; then
+  ENTRY_COUNT=$(jq length "$AGGREGATED_CHANGELOG")
+
+  if [ "$ENTRY_COUNT" -eq 0 ]; then
+    echo "WARNING: No aggregated changelog entries found for ${TARGET}, using fallback."
+    FALLBACK="Bug fixes and improvements."
+    case "$TARGET" in
+      android)
+        for locale in "en-US" "zh-TW"; do
+          mkdir -p "metadata/android/${locale}/changelogs/"
+          echo "$FALLBACK" > "metadata/android/${locale}/changelogs/default.txt"
+        done
+        ;;
+      ios|macos)
+        echo "$FALLBACK" > "en-US.txt"
+        echo "問題修正與效能改善。" > "zh-TW.txt"
+        ;;
+      github)
+        echo "Bug fixes and improvements." > RELEASE_NOTES_GENERATED.md
+        ;;
+    esac
+    exit 0
+  fi
+
+  case "$TARGET" in
+    android)
+      for locale in "en-US" "zh-TW"; do
+        mkdir -p "metadata/android/${locale}/changelogs/"
+        jq -r ".[] | \"* \" + .[\"${locale}\"]" "$AGGREGATED_CHANGELOG" \
+          > "metadata/android/${locale}/changelogs/default.txt"
+      done
+      echo "Generated Android changelog ($ENTRY_COUNT entries)"
+      ;;
+    ios|macos)
+      for locale in "en-US" "zh-TW"; do
+        jq -r ".[] | \"* \" + .[\"${locale}\"]" "$AGGREGATED_CHANGELOG" \
+          > "${locale}.txt"
+      done
+      echo "Generated ${TARGET} changelog ($ENTRY_COUNT entries)"
+      ;;
+    github)
+      VERSION="${RELEASE_VERSION:-unknown}"
+      {
+        echo "## v${VERSION}"
+        echo ""
+        echo "**What's New**"
+        jq -r ".[] | \"- \" + .[\"en-US\"]" "$AGGREGATED_CHANGELOG"
+        echo ""
+        echo "---"
+        echo ""
+        echo "**更新內容**"
+        jq -r ".[] | \"- \" + .[\"zh-TW\"]" "$AGGREGATED_CHANGELOG"
+      } > RELEASE_NOTES_GENERATED.md
+      echo "Generated GitHub release notes ($ENTRY_COUNT entries)"
+      ;;
+    *)
+      echo "ERROR: Unknown target '${TARGET}'. Use: android, ios, macos, or github"
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Legacy path: read from changelog.json keyed by version_code
+# ---------------------------------------------------------------------------
 CHANGELOG_FILE="$SCRIPT_DIR/../../changelog.json"
 
-# Validate version code exists in changelog.json
 if ! jq -e ".\"${VERSION_CODE}\"" "$CHANGELOG_FILE" > /dev/null 2>&1; then
   echo "WARNING: Version code ${VERSION_CODE} not found in ${CHANGELOG_FILE}, skipping changelog generation."
   exit 0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,18 @@ on:
     branches:
       - production
       - develop
+    paths:
+      - 'lib/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+      - '.github/workflows/cd.yml'
+      - '.github/scripts/**'
   workflow_dispatch:
 
 env:
@@ -15,6 +27,7 @@ env:
 permissions:
   contents: write
   actions: write
+  pull-requests: read
 
 jobs:
   prepare:
@@ -36,6 +49,17 @@ jobs:
         run: |
           echo "version_code=${{ vars.VERSION_CODE }}" >> $GITHUB_OUTPUT
           echo "Using version code: ${{ vars.VERSION_CODE }}"
+      - name: Aggregate changelog from merged PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TYPE=${{ github.ref == 'refs/heads/production' && 'stable' || 'beta' }}
+          bash "$GITHUB_WORKSPACE/.github/scripts/aggregate_changelog.sh" "$RELEASE_TYPE" changelog_aggregated.json
+      - name: Upload aggregated changelog
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-aggregated
+          path: changelog_aggregated.json
 
   deploy_android:
     name: Android Play Store
@@ -53,9 +77,15 @@ jobs:
         run: sh ./.github/scripts/decrypt_android_keys.sh
         env:
           KEYS_SECRET_PASSPHRASE: ${{ secrets.KEYS_SECRET_PASSPHRASE }}
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} android
         working-directory: ./android/fastlane
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -91,9 +121,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ env.java_version }}
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} ios
         working-directory: ./ios/fastlane
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -141,9 +177,15 @@ jobs:
       - name: Flutter Initialize
         run: flutter doctor -v
       - run: flutter pub get
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} macos
         working-directory: ./macos/fastlane
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Build macOS
         run: flutter build macos --release --build-number=${{ needs.prepare.outputs.version_code }}
       - name: Decode API Key
@@ -252,8 +294,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate release notes
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} github
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
       - name: Download Windows installer
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,34 @@ on:
     branches:
       - master
       - develop
+    paths:
+      - 'lib/**'
+      - 'test/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches:
       - master
       - develop
+    paths:
+      - 'lib/**'
+      - 'test/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+      - '.github/workflows/ci.yml'
 
 env:
   flutter_version: '3.38.x'

--- a/.github/workflows/pr_changelog.yml
+++ b/.github/workflows/pr_changelog.yml
@@ -66,7 +66,6 @@ jobs:
             exit 0
           }
 
-          gh pr comment "$PR_NUMBER" --body "<!-- changelog-entry
-${ENTRY}
--->"
+          COMMENT_BODY=$(printf '<!-- changelog-entry\n%s\n-->' "$ENTRY")
+          gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
           echo "Posted changelog entry for PR #$PR_NUMBER"

--- a/.github/workflows/pr_changelog.yml
+++ b/.github/workflows/pr_changelog.yml
@@ -1,0 +1,72 @@
+name: PR Changelog Generator
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+    paths:
+      - 'lib/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  generate:
+    name: Generate Changelog Entry
+    if: github.event.pull_request.merged == true
+    runs-on: self-hosted
+    steps:
+      - name: Generate bilingual changelog entry via Ollama
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_BODY="${{ github.event.pull_request.body }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          REQUEST=$(jq -n \
+            --arg title "$PR_TITLE" \
+            --arg body "$PR_BODY" \
+            '{
+              model: "qwen2.5:3b",
+              messages: [
+                {
+                  role: "system",
+                  content: "你是 App 更新說明撰寫員。根據 PR 資訊，用一句話生成使用者可看懂的更新描述。繁體中文使用台灣用語，避免技術術語。只輸出 JSON，格式為 {\"zh-TW\": \"...\", \"en-US\": \"...\"}，不要其他文字。"
+                },
+                {
+                  role: "user",
+                  content: ("PR Title: " + $title + "\nPR Description: " + $body)
+                }
+              ],
+              temperature: 0.3
+            }')
+
+          RESPONSE=$(curl -sf http://localhost:11434/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -d "$REQUEST") || {
+            echo "::warning::Ollama request failed, skipping changelog generation"
+            exit 0
+          }
+
+          ENTRY=$(echo "$RESPONSE" | jq -r '.choices[0].message.content' | tr -d '\n')
+
+          # Validate JSON has required fields
+          echo "$ENTRY" | jq -e '.["zh-TW"] and .["en-US"]' > /dev/null 2>&1 || {
+            echo "::warning::LLM returned invalid JSON: $ENTRY"
+            exit 0
+          }
+
+          gh pr comment "$PR_NUMBER" --body "<!-- changelog-entry
+${ENTRY}
+-->"
+          echo "Posted changelog entry for PR #$PR_NUMBER"


### PR DESCRIPTION
## Summary

- Add `pr_changelog.yml`: on PR merge to `develop`, calls **Ollama (`qwen2.5:3b`)** on the self-hosted runner to generate bilingual (`zh-TW` + `en-US`) user-facing changelog entries, posted as PR comments
- Add `aggregate_changelog.sh`: at release time, queries GitHub API for merged PRs since last release and collects changelog entries from PR comments
- Update `generate_changelog.sh`: reads from `AGGREGATED_CHANGELOG` env var when set; falls back to legacy `changelog.json` for backward compatibility
- Update `cd.yml`: `prepare` job runs aggregate and shares result as artifact to all deploy jobs
- Add path filters to `ci.yml`, `cd.yml`, `pr_changelog.yml` so they only run on app source changes

## beta vs stable distinction

- Push to `develop` → aggregate since last release (pre-release included)
- Push to `production` → aggregate since last **non-prerelease** tag

## GitHub Release format (bilingual)

```
## v3.14.0

**What's New**
- Fix macOS release CI/CD pipeline issues

---

**更新內容**
- 修正 macOS 版本發布 CI/CD 問題
```

## Prerequisites

Install Ollama on self-hosted runner:
```bash
brew install ollama
ollama pull qwen2.5:3b
```

## Test plan

- [ ] Merge a code PR to `develop` → verify PR comment with `<!-- changelog-entry {...} -->` is posted
- [ ] Trigger CD on `develop` → verify `changelog_aggregated.json` artifact is generated
- [ ] Verify GitHub Release notes contain bilingual entries
- [ ] Merge a CI-only PR → verify `pr_changelog.yml` does NOT run (path filter)