### PR TITLE
fix(relogin): 並發 session 過期的單飛登入與成功事件廣播 (#342)

### DIFF
--- a/lib/api/bus_helper.dart
+++ b/lib/api/bus_helper.dart
@@ -198,6 +198,7 @@ class BusHelper with ReloginMixin implements BusProvider {
 
     if (res.data!['code'] == 200 && res.data!['success'] == true) {
       isLogin = true;
+      markReloginSuccess();
     }
     return res.data;
   }

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -99,6 +99,13 @@ class Helper {
     return _instance ??= Helper();
   }
 
+  /// Fires whenever a scraper helper completes a successful (re)login.
+  ///
+  /// UI layers that had a request exhaust its retry budget can listen here
+  /// to retry themselves once another operation has restored the session.
+  Stream<void> get onReloginSuccess =>
+      WebApHelper.instance.onReloginSuccess;
+
   Helper() {
     final String apiHost =
         PreferenceUtil.instance.getString(Constants.apiHost, host);

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -99,12 +99,15 @@ class Helper {
     return _instance ??= Helper();
   }
 
-  /// Fires whenever a scraper helper completes a successful (re)login.
+  /// Fires whenever any scraper helper (WebAP / Bus / Leave) completes a
+  /// successful (re)login.
   ///
   /// UI layers that had a request exhaust its retry budget can listen here
   /// to retry themselves once another operation has restored the session.
-  Stream<void> get onReloginSuccess =>
-      WebApHelper.instance.onReloginSuccess;
+  Stream<void> get onReloginSuccess => _reloginSuccessController.stream;
+
+  final StreamController<void> _reloginSuccessController =
+      StreamController<void>.broadcast();
 
   Helper() {
     final String apiHost =
@@ -183,6 +186,22 @@ class Helper {
     registry.register<LeaveProvider>(
       ScraperSource.webap, LeaveHelper.instance,
     );
+
+    // Forward relogin-success events from every helper that uses
+    // ReloginMixin so consumers can subscribe once via
+    // [Helper.instance.onReloginSuccess] instead of knowing about each
+    // helper individually.
+    void forward(Stream<void> source) {
+      source.listen((_) {
+        if (!_reloginSuccessController.isClosed) {
+          _reloginSuccessController.add(null);
+        }
+      });
+    }
+
+    forward(WebApHelper.instance.onReloginSuccess);
+    forward(BusHelper.instance.onReloginSuccess);
+    forward(LeaveHelper.instance.onReloginSuccess);
 
     // Register cleanup callbacks for each sub-helper.
     // This replaces the manual cleanup in clearSetting() and ensures

--- a/lib/api/leave_helper.dart
+++ b/lib/api/leave_helper.dart
@@ -144,6 +144,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
       ),
     );
     if (result ?? false) {
+      markReloginSuccess();
       return LoginResponse();
     } else {
       throw GeneralResponse(statusCode: ApStatusCode.cancel, message: 'cancel');

--- a/lib/api/relogin_mixin.dart
+++ b/lib/api/relogin_mixin.dart
@@ -77,6 +77,12 @@ mixin ReloginMixin {
   ///
   /// The retry counter is **per-call** (local variable), not shared across
   /// operations, so one failing operation cannot block others.
+  ///
+  /// **Contract:** the [relogin] callback is responsible for calling
+  /// [markReloginSuccess] on successful authentication. This ensures both
+  /// the race-condition timestamp and the [onReloginSuccess] broadcast stay
+  /// consistent whether the login was triggered by top-level `login()` or
+  /// by this method.
   Future<T> withAutoRelogin<T>({
     required Future<T> Function() action,
     required Future<void> Function() relogin,
@@ -123,8 +129,9 @@ mixin ReloginMixin {
         _reloginInFlight = completer;
         try {
           await relogin();
-          _lastSuccessfulRelogin = DateTime.now();
-          _emitReloginSuccess();
+          // The relogin callback is expected to call [markReloginSuccess]
+          // itself (see contract above), so we don't duplicate state updates
+          // or event emissions here.
           completer.complete();
         } catch (err, st) {
           completer.completeError(err, st);

--- a/lib/api/relogin_mixin.dart
+++ b/lib/api/relogin_mixin.dart
@@ -111,16 +111,12 @@ mixin ReloginMixin {
         }
 
         // Single-flight relogin: piggy-back on any in-progress relogin.
+        // If it fails (e.g. wrong password), propagate the same failure to
+        // all waiters instead of letting each one run its own retry budget
+        // and trigger redundant captcha attempts.
         final Completer<void>? inFlight = _reloginInFlight;
         if (inFlight != null) {
-          try {
-            await inFlight.future;
-          } catch (_) {
-            // The in-flight relogin failed; the caller that started it
-            // will rethrow its own error. We retry the loop, which will
-            // either succeed (session may have recovered by another
-            // path) or hit the next retry slot.
-          }
+          await inFlight.future;
           await Future<void>.delayed(retryDelay);
           continue;
         }

--- a/lib/api/relogin_mixin.dart
+++ b/lib/api/relogin_mixin.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 /// Mixin for handling session-level re-login when a scraper session expires.
 ///
 /// This is distinct from HTTP-level retry (handled by [RetryInterceptor] in
@@ -9,6 +11,12 @@
 /// (`reLoginReTryCounts`) shared across ALL operations. When one operation
 /// exhausted the retry limit, ALL subsequent operations would immediately fail.
 /// This mixin uses **per-call** counting so operations are independent.
+///
+/// Single-flight relogin: when multiple concurrent calls all see a session
+/// expired error, only the first call actually performs [relogin]. Others
+/// wait on the same in-flight [Completer] and then retry their own action.
+/// This avoids hammering the login endpoint (and its captcha) with N parallel
+/// login attempts when any app-start burst of requests all expire together.
 mixin ReloginMixin {
   /// Maximum number of re-login attempts per call. Override in each helper.
   int get maxRelogins;
@@ -32,12 +40,18 @@ mixin ReloginMixin {
   /// (race condition, see #342) — retrying with a delay is enough.
   DateTime? _lastSuccessfulRelogin;
 
+  /// Holds the in-flight relogin [Completer] while a relogin is running.
+  /// Concurrent callers awaiting session recovery wait on this future
+  /// instead of launching their own relogin (single-flight pattern).
+  Completer<void>? _reloginInFlight;
+
   /// Executes [action] with automatic re-login on session expiry.
   ///
   /// When [isSessionExpired] returns true for a caught error:
   /// - If the last successful login was within [recentLoginWindow], assumes
   ///   a server race condition and retries with only a delay (no re-login).
-  /// - Otherwise, calls [relogin] to re-authenticate, then retries.
+  /// - Otherwise, performs a single-flight [relogin]: the first caller runs
+  ///   it, concurrent callers await the same future, then all retry.
   ///
   /// After [maxRelogins] attempts, the original error is rethrown.
   ///
@@ -67,13 +81,37 @@ mixin ReloginMixin {
           // condition (#342), not real session expiry. Just delay and
           // retry the request without re-authenticating.
           await Future<void>.delayed(retryDelay);
-        } else {
-          // Either not recently logged in, or the delay-only retry
-          // already failed. Session actually expired — re-authenticate.
+          continue;
+        }
+
+        // Single-flight relogin: piggy-back on any in-progress relogin.
+        final Completer<void>? inFlight = _reloginInFlight;
+        if (inFlight != null) {
+          try {
+            await inFlight.future;
+          } catch (_) {
+            // The in-flight relogin failed; the caller that started it
+            // will rethrow its own error. We retry the loop, which will
+            // either succeed (session may have recovered by another
+            // path) or hit the next retry slot.
+          }
+          await Future<void>.delayed(retryDelay);
+          continue;
+        }
+
+        final Completer<void> completer = Completer<void>();
+        _reloginInFlight = completer;
+        try {
           await relogin();
           _lastSuccessfulRelogin = DateTime.now();
-          await Future<void>.delayed(retryDelay);
+          completer.complete();
+        } catch (err, st) {
+          completer.completeError(err, st);
+          rethrow;
+        } finally {
+          _reloginInFlight = null;
         }
+        await Future<void>.delayed(retryDelay);
       }
     }
   }
@@ -85,7 +123,8 @@ class ApSessionExpiredException implements Exception {
   const ApSessionExpiredException();
 
   @override
-  String toString() => 'ApSessionExpiredException: WebAP session expired (code 2)';
+  String toString() =>
+      'ApSessionExpiredException: WebAP session expired (code 2)';
 }
 
 /// Exception thrown when the Bus system returns a "未登入" (not logged in)

--- a/lib/api/relogin_mixin.dart
+++ b/lib/api/relogin_mixin.dart
@@ -23,13 +23,33 @@ mixin ReloginMixin {
 
   /// Marks that a login has just succeeded. Call this from the login method
   /// so [withAutoRelogin] can distinguish race conditions from real expiry.
+  /// Also broadcasts on [onReloginSuccess] so UI consumers can refresh data
+  /// that was lost to an earlier exhausted-retry failure.
   void markReloginSuccess() {
     _lastSuccessfulRelogin = DateTime.now();
+    _emitReloginSuccess();
   }
 
   /// Resets the relogin timestamp (e.g. on logout).
   void resetReloginState() {
     _lastSuccessfulRelogin = null;
+  }
+
+  /// Broadcast stream that fires whenever a relogin (or top-level login that
+  /// called [markReloginSuccess]) completes successfully.
+  ///
+  /// Useful for UI layers: if a request gave up after [maxRelogins] attempts
+  /// but a *later* unrelated request then succeeds in reauthenticating, the
+  /// giver-upper can listen to this stream and retry itself.
+  Stream<void> get onReloginSuccess => _reloginSuccessController.stream;
+
+  final StreamController<void> _reloginSuccessController =
+      StreamController<void>.broadcast();
+
+  void _emitReloginSuccess() {
+    if (!_reloginSuccessController.isClosed) {
+      _reloginSuccessController.add(null);
+    }
   }
 
   /// Tracks when the last successful login/re-login completed.
@@ -104,6 +124,7 @@ mixin ReloginMixin {
         try {
           await relogin();
           _lastSuccessfulRelogin = DateTime.now();
+          _emitReloginSuccess();
           completer.complete();
         } catch (err, st) {
           completer.completeError(err, st);

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
@@ -57,6 +58,9 @@ class HomePageState extends State<HomePage> {
   UserInfo? userInfo;
   CourseData? courseData;
   BusReservationsData? busReservationsData;
+
+  StreamSubscription<void>? _reloginSub;
+  bool _userInfoFetchFailed = false;
 
   String get sectionImage {
     final String department = userInfo?.department ?? '';
@@ -150,11 +154,18 @@ class HomePageState extends State<HomePage> {
       }
       await _checkData(first: true);
     });
+    _reloginSub = Helper.instance.onReloginSuccess.listen((_) {
+      if (!mounted) return;
+      if (_userInfoFetchFailed || userInfo == null) {
+        _getUserInfo();
+      }
+    });
     super.initState();
   }
 
   @override
   void dispose() {
+    _reloginSub?.cancel();
     super.dispose();
   }
 
@@ -669,6 +680,7 @@ class HomePageState extends State<HomePage> {
     } else {
       try {
         final UserInfo data = await Helper.instance.getUsersInfo();
+        _userInfoFetchFailed = false;
         if (mounted) {
           setState(() {
             userInfo = data;
@@ -685,6 +697,7 @@ class HomePageState extends State<HomePage> {
           }
         }
       } on DioException catch (e) {
+        _userInfoFetchFailed = true;
         if (e.hasResponse) {
           AnalyticsUtil.instance.logApiEvent(
             'getUserInfo',
@@ -693,6 +706,7 @@ class HomePageState extends State<HomePage> {
           );
         }
       } catch (e, s) {
+        _userInfoFetchFailed = true;
         CrashlyticsUtil.instance.recordError(e, s);
       }
     }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -61,6 +61,7 @@ class HomePageState extends State<HomePage> {
 
   StreamSubscription<void>? _reloginSub;
   bool _userInfoFetchFailed = false;
+  bool _userInfoFetchInProgress = false;
 
   String get sectionImage {
     final String department = userInfo?.department ?? '';
@@ -156,7 +157,10 @@ class HomePageState extends State<HomePage> {
     });
     _reloginSub = Helper.instance.onReloginSuccess.listen((_) {
       if (!mounted) return;
-      if (_userInfoFetchFailed || userInfo == null) {
+      // Only retry when a previous fetch actually failed. The initial
+      // login flow calls `_getUserInfo()` directly, so no retry is needed
+      // just because the stream fired.
+      if (_userInfoFetchFailed) {
         _getUserInfo();
       }
     });
@@ -675,9 +679,14 @@ class HomePageState extends State<HomePage> {
   }
 
   Future<void> _getUserInfo() async {
-    if (PreferenceUtil.instance.getBool(Constants.prefIsOfflineLogin, false)) {
-      userInfo = UserInfo.load(Helper.username!);
-    } else {
+    if (_userInfoFetchInProgress) return;
+    _userInfoFetchInProgress = true;
+    try {
+      if (PreferenceUtil.instance
+          .getBool(Constants.prefIsOfflineLogin, false)) {
+        userInfo = UserInfo.load(Helper.username!);
+        return;
+      }
       try {
         final UserInfo data = await Helper.instance.getUsersInfo();
         _userInfoFetchFailed = false;
@@ -709,6 +718,8 @@ class HomePageState extends State<HomePage> {
         _userInfoFetchFailed = true;
         CrashlyticsUtil.instance.recordError(e, s);
       }
+    } finally {
+      _userInfoFetchInProgress = false;
     }
   }
 


### PR DESCRIPTION
## 摘要

延續 #342。解決近期 log 中觀察到的兩個殘留問題——App 啟動時 `getUsersInfo`、`getCourseTables`、`getBusReservations` 三個請求同時競爭時會發生：

1. **N 次平行 captcha 辨識** — 多個請求同時遇到 session 過期，各自觸發 relogin，導致多次 captcha 嘗試（偶爾還會 OCR 失敗跑出 `SegmentationException`）。
2. **使用者資料永久空白** — `_getUserInfo` 耗盡 `maxRelogins` 後放棄；稍後 `_getCourseTables` 透過自己的自動恢復流程 relogin 成功，但沒有任何機制通知 HomePage 重抓使用者資料，整個 session 期間頭像/姓名都是空的。

## 變更內容

### `lib/api/relogin_mixin.dart`

- **單飛（single-flight）relogin**：新增 `_reloginInFlight` Completer。第一個偵測到 session 過期的呼叫者才真正執行 `relogin()`，其他並發呼叫者等在同一個 future 上，完成後各自重試自己的 action。
- **`onReloginSuccess` 廣播 stream**：由 `markReloginSuccess()` 內部觸發，供 UI 層訂閱重抓資料。
- **Callback 責任歸位**：明確規範 `relogin` callback 必須自行呼叫 `markReloginSuccess()`；`withAutoRelogin` 不再重複記錄時間戳或廣播事件，避免 WebAP 一次 relogin 觸發兩次事件。

### `lib/api/bus_helper.dart` / `lib/api/leave_helper.dart`

- 補上 `busLogin()` / `login()` 成功後呼叫 `markReloginSuccess()`。原本只有 WebAP 會廣播，現在三個 helper 的 relogin 成功事件行為一致。

### `lib/api/helper.dart`

- 透過 `Helper.instance.onReloginSuccess` 暴露事件，UI 層不需要直接 import 個別 helper。

### `lib/pages/home_page.dart`

- `initState` 訂閱 `Helper.instance.onReloginSuccess`，`dispose` 取消訂閱。
- 新增 `_userInfoFetchFailed` 旗標；當 relogin 事件觸發且使用者資料仍缺失時，重跑 `_getUserInfo()`。

## 為什麼這個設計適合未來擴充

所有走 `ReloginMixin` 的 helper 請求都自動受惠：
- 單飛機制內建，不需要每個呼叫端各自處理並發協調。
- 事件廣播與 race-condition 時間戳統一由 `markReloginSuccess()` 負責，只要 login 方法有呼叫就正確運作。
- 只有需要「事後補抓」的 UI（例如首頁使用者資料區塊）才需要訂閱 stream。

## 測試計畫

- [ ] App 以過期/無效 session 啟動 — 即使多個 WebAP 請求同時發出，log 中只應出現一次 captcha 嘗試
- [ ] 故意讓 `_getUserInfo` 失敗（例如 WebAP 暫時中斷），之後觸發課表抓取 — 使用者資料應在課表抓取成功後自動補上
- [ ] WebAP relogin 只觸發一次 `onReloginSuccess`（不再雙重觸發）
- [ ] Bus 在 session 過期後觸發 relogin — 驗證 `onReloginSuccess` 有正確廣播
- [ ] Leave（WebView）登入完成後 — 驗證 `onReloginSuccess` 有正確廣播
- [ ] 正常登入流程無 regression
- [ ] 登出流程正確清除狀態