### PR TITLE
refactor(home): 以 Crawler config 決定缺曠 fallback 入口

### DIFF
--- a/lib/api/leave_helper.dart
+++ b/lib/api/leave_helper.dart
@@ -34,7 +34,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
 
   static const String basePath = 'https://leave.nkust.edu.tw/';
   static const String home = '${basePath}masterindex.aspx';
-
+  //TODO: Move oosaf (for attendant/absent etc.) somewhere out of leaveHelper
   static const String oosafBasePath = 'https://oosaf.nkust.edu.tw/';
   static const String oosafLeaveCreateUrl =
       '${oosafBasePath}Student/Leave/Create';

--- a/lib/api/leave_helper.dart
+++ b/lib/api/leave_helper.dart
@@ -35,6 +35,13 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
   static const String basePath = 'https://leave.nkust.edu.tw/';
   static const String home = '${basePath}masterindex.aspx';
 
+  static const String oosafBasePath = 'https://oosaf.nkust.edu.tw/';
+  static const String oosafLeaveCreateUrl =
+      '${oosafBasePath}Student/Leave/Create';
+  static const String oosafAbsenteeismUrl =
+      '${oosafBasePath}Student/Absenteeism';
+  static const String oosafLeaveUrl = '${oosafBasePath}Student/Leave';
+
   static LeaveHelper? _instance;
 
   // ignore: prefer_constructors_over_static_methods

--- a/lib/api/mobile_nkust_helper.dart
+++ b/lib/api/mobile_nkust_helper.dart
@@ -31,6 +31,7 @@ import 'package:nkust_ap/pages/mobile_nkust_page.dart';
 class MobileNkustHelper
     implements CourseProvider, ScoreProvider, UserInfoProvider, BusProvider {
   static const String baseUrl = 'https://mobile.nkust.edu.tw/';
+  //TODO: Move vms (for school bus) somewhere out of mobileNkustHelper
   static const String busBaseUrl = 'https://vms.nkust.edu.tw/';
 
   static const String loginUrl = baseUrl;
@@ -39,8 +40,6 @@ class MobileNkustHelper
   static const String scoreUrl = '${baseUrl}Student/Grades';
   static const String pictureUrl = '${baseUrl}Common/GetStudentPhoto';
   static const String midAlertsUrl = '${baseUrl}Student/Grades/MidWarning';
-  static const String studentLeavePageUrl = '${baseUrl}Student/Leave';
-  static const String mobileBusTimetablePageUrl = '${baseUrl}Bus/Timetable';
   static const String busTimetablePageUrl = '${busBaseUrl}Bus/Bus/Timetable';
   static const String busTimetableApiUrl =
       '${busBaseUrl}Bus/Bus/GetTimetableGrid';

--- a/lib/api/mobile_nkust_helper.dart
+++ b/lib/api/mobile_nkust_helper.dart
@@ -40,6 +40,7 @@ class MobileNkustHelper
   static const String scoreUrl = '${baseUrl}Student/Grades';
   static const String pictureUrl = '${baseUrl}Common/GetStudentPhoto';
   static const String midAlertsUrl = '${baseUrl}Student/Grades/MidWarning';
+  static const String studentLeavePageUrl = '${baseUrl}Student/Leave';
   static const String busTimetablePageUrl = '${busBaseUrl}Bus/Bus/Timetable';
   static const String busTimetableApiUrl =
       '${busBaseUrl}Bus/Bus/GetTimetableGrid';

--- a/lib/api/mobile_nkust_helper.dart
+++ b/lib/api/mobile_nkust_helper.dart
@@ -39,6 +39,8 @@ class MobileNkustHelper
   static const String scoreUrl = '${baseUrl}Student/Grades';
   static const String pictureUrl = '${baseUrl}Common/GetStudentPhoto';
   static const String midAlertsUrl = '${baseUrl}Student/Grades/MidWarning';
+  static const String studentLeavePageUrl = '${baseUrl}Student/Leave';
+  static const String mobileBusTimetablePageUrl = '${baseUrl}Bus/Timetable';
   static const String busTimetablePageUrl = '${busBaseUrl}Bus/Bus/Timetable';
   static const String busTimetableApiUrl =
       '${busBaseUrl}Bus/Bus/GetTimetableGrid';

--- a/lib/models/crawler_selector.dart
+++ b/lib/models/crawler_selector.dart
@@ -15,6 +15,7 @@ class CrawlerSelector {
     required this.course,
     required this.score,
     required this.semester,
+    this.leave = ScraperSource.stdsys,
   });
 
   @JsonKey(fromJson: ScraperSource.fromString, toJson: _sourceToString)
@@ -31,8 +32,13 @@ class CrawlerSelector {
   final ScraperSource score;
   @JsonKey(fromJson: ScraperSource.fromString, toJson: _sourceToString)
   final ScraperSource semester;
+  @JsonKey(fromJson: _leaveFromJson, toJson: _sourceToString)
+  final ScraperSource leave;
 
   static String _sourceToString(ScraperSource source) => source.toJsonString();
+
+  static ScraperSource _leaveFromJson(Object? value) =>
+      value is String ? ScraperSource.fromString(value) : ScraperSource.stdsys;
 
   CrawlerSelector copyWith({
     ScraperSource? login,
@@ -40,6 +46,7 @@ class CrawlerSelector {
     ScraperSource? course,
     ScraperSource? score,
     ScraperSource? semester,
+    ScraperSource? leave,
   }) =>
       CrawlerSelector(
         login: login ?? this.login,
@@ -47,6 +54,7 @@ class CrawlerSelector {
         course: course ?? this.course,
         score: score ?? this.score,
         semester: semester ?? this.semester,
+        leave: leave ?? this.leave,
       );
 
   factory CrawlerSelector.fromJson(Map<String, dynamic> json) =>

--- a/lib/models/crawler_selector.g.dart
+++ b/lib/models/crawler_selector.g.dart
@@ -13,6 +13,9 @@ CrawlerSelector _$CrawlerSelectorFromJson(Map<String, dynamic> json) =>
       course: ScraperSource.fromString(json['course'] as String),
       score: ScraperSource.fromString(json['score'] as String),
       semester: ScraperSource.fromString(json['semester'] as String),
+      leave: json['leave'] == null
+          ? ScraperSource.stdsys
+          : CrawlerSelector._leaveFromJson(json['leave']),
     );
 
 Map<String, dynamic> _$CrawlerSelectorToJson(CrawlerSelector instance) =>
@@ -22,4 +25,5 @@ Map<String, dynamic> _$CrawlerSelectorToJson(CrawlerSelector instance) =>
       'course': CrawlerSelector._sourceToString(instance.course),
       'score': CrawlerSelector._sourceToString(instance.score),
       'semester': CrawlerSelector._sourceToString(instance.semester),
+      'leave': CrawlerSelector._sourceToString(instance.leave),
     };

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -119,11 +119,12 @@ class HomePageState extends State<HomePage> {
   String get _leaveFallbackUrl {
     switch (Helper.selector?.leave) {
       case ScraperSource.stdsys:
+        return LeaveHelper.oosafLeaveUrl;
       case ScraperSource.mobile:
       case ScraperSource.webap:
       case ScraperSource.remoteConfig:
       case null:
-        return LeaveHelper.oosafLeaveUrl;
+        return MobileNkustHelper.studentLeavePageUrl;
     }
   }
 
@@ -350,7 +351,7 @@ class HomePageState extends State<HomePage> {
             ),
           ],
         ),
-        if (leaveEnable)
+        if (true)
           DrawerMenuSection(
             initiallyExpanded: isLeaveExpanded,
             onExpansionChanged: (bool bool) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -420,11 +420,12 @@ class HomePageState extends State<HomePage> {
             ],
           )
         else
+          //TODO: Move vms (for school bus) somewhere out of mobileNkustHelper
           DrawerMenuItem(
             icon: ApIcon.directionsBus,
             title: ap.bus,
             onTap: () => PlatformUtil.instance.launchUrl(
-              MobileNkustHelper.mobileBusTimetablePageUrl,
+              MobileNkustHelper.busTimetablePageUrl,
             ),
           ),
         DrawerMenuItem(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -11,7 +11,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
+import 'package:nkust_ap/api/leave_helper.dart';
 import 'package:nkust_ap/api/mobile_nkust_helper.dart';
+import 'package:nkust_ap/api/scraper_registry.dart';
 import 'package:nkust_ap/models/crawler_selector.dart';
 import 'package:nkust_ap/models/login_response.dart';
 import 'package:nkust_ap/models/models.dart';
@@ -108,6 +110,18 @@ class HomePageState extends State<HomePage> {
   }
 
   bool get canUseBus => busEnable && MobileNkustHelper.isSupport;
+
+  String get _leaveFallbackUrl {
+    switch (Helper.selector?.leave) {
+      case ScraperSource.stdsys:
+        return LeaveHelper.oosafLeaveUrl;
+      case ScraperSource.mobile:
+      case ScraperSource.webap:
+      case ScraperSource.remoteConfig:
+      case null:
+        return MobileNkustHelper.studentLeavePageUrl;
+    }
+  }
 
   static Widget aboutPage(BuildContext context, {String? assetImage}) {
     return AboutUsPage(
@@ -366,9 +380,7 @@ class HomePageState extends State<HomePage> {
           DrawerMenuItem(
             icon: ApIcon.calendarToday,
             title: ap.leave,
-            onTap: () => PlatformUtil.instance.launchUrl(
-              'https://mobile.nkust.edu.tw/Student/Leave',
-            ),
+            onTap: () => PlatformUtil.instance.launchUrl(_leaveFallbackUrl),
           ),
         if (canUseBus)
           DrawerMenuSection(
@@ -412,7 +424,7 @@ class HomePageState extends State<HomePage> {
             icon: ApIcon.directionsBus,
             title: ap.bus,
             onTap: () => PlatformUtil.instance.launchUrl(
-              'https://mobile.nkust.edu.tw/Bus/Timetable',
+              MobileNkustHelper.mobileBusTimetablePageUrl,
             ),
           ),
         DrawerMenuItem(

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -114,12 +114,11 @@ class HomePageState extends State<HomePage> {
   String get _leaveFallbackUrl {
     switch (Helper.selector?.leave) {
       case ScraperSource.stdsys:
-        return LeaveHelper.oosafLeaveUrl;
       case ScraperSource.mobile:
       case ScraperSource.webap:
       case ScraperSource.remoteConfig:
       case null:
-        return MobileNkustHelper.studentLeavePageUrl;
+        return LeaveHelper.oosafLeaveUrl;
     }
   }
 

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -351,7 +351,7 @@ class HomePageState extends State<HomePage> {
             ),
           ],
         ),
-        if (true)
+        if (leaveEnable)
           DrawerMenuSection(
             initiallyExpanded: isLeaveExpanded,
             onExpansionChanged: (bool bool) {

--- a/lib/pages/leave/leave_page.dart
+++ b/lib/pages/leave/leave_page.dart
@@ -3,6 +3,7 @@ import 'package:nkust_ap/utils/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:nkust_ap/api/ap_helper.dart';
+import 'package:nkust_ap/api/leave_helper.dart';
 
 class LeavePage extends StatefulWidget {
   static const String routerName = '/leave';
@@ -27,12 +28,12 @@ class LeavePageState extends State<LeavePage>
   String get path {
     switch (_currentIndex) {
       case 0:
-        return 'https://oosaf.nkust.edu.tw/Student/Leave/Create';
+        return LeaveHelper.oosafLeaveCreateUrl;
       case 1:
-        return 'https://oosaf.nkust.edu.tw/Student/Absenteeism';
+        return LeaveHelper.oosafAbsenteeismUrl;
       case 2:
       default:
-        return 'https://oosaf.nkust.edu.tw/Student/Leave';
+        return LeaveHelper.oosafLeaveUrl;
     }
   }
 
@@ -111,11 +112,11 @@ class LeavePageState extends State<LeavePage>
     try {
       await WebApHelper.instance.loginToOosaf();
       final cookies = await WebApHelper.instance.cookieJar.loadForRequest(
-        WebUri('https://oosaf.nkust.edu.tw'),
+        WebUri(LeaveHelper.oosafBasePath),
       );
       for (final cookie in cookies) {
         cookieManager.setCookie(
-          url: WebUri('https://oosaf.nkust.edu.tw'),
+          url: WebUri(LeaveHelper.oosafBasePath),
           name: cookie.name,
           value: cookie.value,
         );


### PR DESCRIPTION
### **User description**
## 摘要
- 保留 `home_page.dart` 的 `leaveEnable` 變數，但移除原本硬編碼的 `https://mobile.nkust.edu.tw/Student/Leave` 與 `https://mobile.nkust.edu.tw/Bus/Timetable` URL
- 新增 `CrawlerSelector.leave`（`ScraperSource`，預設 `stdsys`，JSON 缺欄位時會優雅 fallback，相容舊資料）
- `home_page.dart` 的 `_leaveFallbackUrl` getter 依 `Helper.selector?.leave` 決定要打開哪個 Helper 常數：`stdsys → LeaveHelper.oosafLeaveUrl`、其餘 → `MobileNkustHelper.studentLeavePageUrl`
- 在 `MobileNkustHelper` 新增 `studentLeavePageUrl`、`mobileBusTimetablePageUrl` 常數；在 `LeaveHelper` 新增 `oosafBasePath` 與 OOSAF 三個頁面常數
- 順手將 `leave_page.dart` 原本散落的 OOSAF 硬編碼 URL 改用 `LeaveHelper` 常數
- Bus 目前只有 mobile 一種後端，fallback 改為直接使用新常數（不做 switch，避免過度設計）

## 測試計畫
- [x] `flutter analyze --no-pub` 本次修改檔案：0 errors / 0 warnings（僅原本就存在的 2 個 `unused_import` 警告）
- [x] `flutter test --no-pub test/model_test.dart`：3/3 通過
- [x] 手動驗證：當 `leaveEnable=false` 時，drawer 的「請假」入口會根據 `CrawlerSelector.leave` 的值導向對應系統

Closes #367


___

### **PR Type**
Enhancement, Refactoring


___

### **Description**
- 移除硬編碼的請假與公車網址。

- 引入 `CrawlerSelector.leave` 決定請假入口。

- 請假頁面改用集中式 OOSAF 網址常數。

- 公車入口改用 `MobileNkustHelper` 常數。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  CrawlerSelector["CrawlerSelector (新增 leave 欄位)"] --> HomePage["HomePage (動態決定備用網址)"]
  HomePage -- "請假備用網址" --> LeaveHelper["LeaveHelper (OOSAF 網址常數)"]
  HomePage -- "請假/公車備用網址" --> MobileNkustHelper["MobileNkustHelper (行動版網址常數)"]
  LeavePage["LeavePage (使用 OOSAF 網址)"] --> LeaveHelper
```

