### PR TITLE
refactor(api): 爬蟲登入流程錯誤處理改用類型化例外 (#372)

### DIFF
--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -200,17 +200,18 @@ class WebApHelper
         // retrying with the same credentials would only hammer the login
         // endpoint.
         rethrow;
-      } on DioException catch (e) {
-        // Transport-layer failures (no internet, DNS, SSL, timeout)
-        // short-circuit the captcha retry loop — we never got a response,
-        // so another attempt with a fresh captcha is pointless and only
-        // masks the real network problem behind a bogus "captcha error"
-        // message to the user. See GH issue triage: login screen showed
-        // "驗證碼錯誤" when the device was simply offline.
-        if (NetworkException.isTransport(e)) {
-          throw NetworkException.from(e);
+      } on DioException catch (e, s) {
+        // Transport-layer failures (no internet, DNS, SSL, timeout) AND
+        // server error responses (badResponse with 5xx / 4xx) both
+        // short-circuit the captcha retry loop — in neither case would
+        // another captcha attempt help, and masking them as "captcha
+        // failed" misleads the user. Delegate the translation to the
+        // shared DioException extension.
+        if (NetworkException.isTransport(e) ||
+            e.type == DioExceptionType.badResponse) {
+          throw e.toApException();
         }
-        CrashlyticsUtil.instance.recordError(e, StackTrace.current);
+        CrashlyticsUtil.instance.recordError(e, s);
         log(e.toString());
       } catch (e, s) {
         CrashlyticsUtil.instance.recordError(e, s);

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -517,9 +517,8 @@ class WebApHelper
         WebApParser.instance.enrollmentLetterPathParser(query.data as String);
 
     if (pdfPath == null || pdfPath.isEmpty) {
-      throw GeneralResponse(
-        statusCode: ApStatusCode.unknownError,
-        message: 'cannot find pdf url',
+      throw ServerException(
+        message: 'enrollment letter PDF url not found in response',
       );
     }
 

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -198,9 +198,20 @@ class WebApHelper
       } on ApException {
         // Non-captcha auth / server errors should propagate immediately —
         // retrying with the same credentials would only hammer the login
-        // endpoint. Only captcha/network issues (which land in the generic
-        // catch below) deserve a retry.
+        // endpoint.
         rethrow;
+      } on DioException catch (e) {
+        // Transport-layer failures (no internet, DNS, SSL, timeout)
+        // short-circuit the captcha retry loop — we never got a response,
+        // so another attempt with a fresh captcha is pointless and only
+        // masks the real network problem behind a bogus "captcha error"
+        // message to the user. See GH issue triage: login screen showed
+        // "驗證碼錯誤" when the device was simply offline.
+        if (NetworkException.isTransport(e)) {
+          throw NetworkException.from(e);
+        }
+        CrashlyticsUtil.instance.recordError(e, StackTrace.current);
+        log(e.toString());
       } catch (e, s) {
         CrashlyticsUtil.instance.recordError(e, s);
         log(e.toString());

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -200,20 +200,16 @@ class WebApHelper
         // retrying with the same credentials would only hammer the login
         // endpoint.
         rethrow;
-      } on DioException catch (e, s) {
-        // Transport-layer failures (no internet, DNS, SSL, timeout) AND
-        // server error responses (badResponse with 5xx / 4xx) both
-        // short-circuit the captcha retry loop — in neither case would
-        // another captcha attempt help, and masking them as "captcha
-        // failed" misleads the user. Delegate the translation to the
-        // shared DioException extension.
-        if (NetworkException.isTransport(e) ||
-            e.type == DioExceptionType.badResponse) {
-          throw e.toApException();
-        }
-        CrashlyticsUtil.instance.recordError(e, s);
-        log(e.toString());
+      } on DioException catch (e) {
+        // Any DioException — transport failure, server 4xx/5xx, or user
+        // cancellation — terminates the captcha retry loop. Another
+        // attempt with a fresh captcha cannot help when the HTTP layer
+        // itself failed, and retrying a cancelled request would waste
+        // work and produce misleading "captcha error" messages.
+        throw e.toApException();
       } catch (e, s) {
+        // Truly unexpected errors (parser bugs, etc.) are logged and
+        // allowed to trigger another captcha attempt.
         CrashlyticsUtil.instance.recordError(e, s);
         log(e.toString());
       }

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -9,6 +9,7 @@ import 'package:dio/io.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:nkust_ap/api/api_config.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/api/leave_helper.dart';
 import 'package:nkust_ap/api/mobile_nkust_helper.dart';
@@ -174,35 +175,41 @@ class WebApHelper
               expireTime: DateTime.now().add(const Duration(hours: 6)),
             );
           case 1:
-            throw GeneralResponse(
-              statusCode: ApStatusCode.userDataError,
+            throw AuthException(
+              AuthFailureReason.invalidCredentials,
               message: 'username or password error',
             );
           case 5:
-            throw GeneralResponse(
-              statusCode: ApStatusCode.passwordFiveTimesError,
-              message: 'username or password error',
+            throw AuthException(
+              AuthFailureReason.tooManyAttempts,
+              message: 'too many failed attempts',
             );
           case 500:
-            throw GeneralResponse(
+            throw ServerException(
               statusCode: ApStatusCode.schoolServerError,
               message: 'school server error',
             );
           default:
-            throw GeneralResponse(
+            throw ServerException(
               statusCode: code,
-              message: 'unknown error',
+              message: 'unknown login response code: $code',
             );
         }
+      } on ApException {
+        // Non-captcha auth / server errors should propagate immediately —
+        // retrying with the same credentials would only hammer the login
+        // endpoint. Only captcha/network issues (which land in the generic
+        // catch below) deserve a retry.
+        rethrow;
       } catch (e, s) {
         CrashlyticsUtil.instance.recordError(e, s);
         log(e.toString());
       }
     }
     //
-    throw GeneralResponse(
-      statusCode: ApStatusCode.unknownError,
-      message: 'captcha error or unknown error',
+    throw CaptchaException(
+      attempts: retryCounts,
+      message: 'captcha failed after $retryCounts attempts',
     );
   }
 

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -267,7 +267,7 @@ class WebApHelper
         expireTime: DateTime.now().add(const Duration(hours: 1)),
       );
     } else {
-      throw GeneralResponse(statusCode: ApStatusCode.cancel, message: 'cancel');
+      throw AuthException(AuthFailureReason.unknown, message: 'cross-system SSO did not land on target page');
     }
   }
 
@@ -306,7 +306,7 @@ class WebApHelper
         expireTime: DateTime.now().add(const Duration(hours: 1)),
       );
     } else {
-      throw GeneralResponse(statusCode: ApStatusCode.cancel, message: 'cancel');
+      throw AuthException(AuthFailureReason.unknown, message: 'cross-system SSO did not land on target page');
     }
   }
 
@@ -354,7 +354,7 @@ class WebApHelper
         expireTime: _stdsysLoginExpireTime!,
       );
     } else {
-      throw GeneralResponse(statusCode: ApStatusCode.cancel, message: 'cancel');
+      throw AuthException(AuthFailureReason.unknown, message: 'cross-system SSO did not land on target page');
     }
   }
 
@@ -401,7 +401,7 @@ class WebApHelper
         expireTime: DateTime.now().add(const Duration(hours: 1)),
       );
     }
-    throw GeneralResponse(statusCode: ApStatusCode.cancel, message: 'cancel');
+    throw AuthException(AuthFailureReason.unknown, message: 'cross-system SSO did not land on target page');
   }
 
   Future<LoginResponse?> checkLogin() async {

--- a/lib/api/bus_helper.dart
+++ b/lib/api/bus_helper.dart
@@ -7,6 +7,7 @@ import 'package:crypto/crypto.dart';
 import 'package:dio/io.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:nkust_ap/api/api_config.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/api/parser/bus_parser.dart';
 import 'package:nkust_ap/api/capability/bus_provider.dart';
@@ -160,24 +161,23 @@ class BusHelper with ReloginMixin implements BusProvider {
     busEncryptObject = BusEncrypt(jsCode: res.data!);
   }
 
-  Future<Map<String, dynamic>?> busLogin() async {
-    /*
-    Return type Map<String, dynamic>(from Json)
-    response data (from NKUST)
-    {
-      'success': true,
-      'code': 200,
-      'message': 'User Name',
-      'count': 1,
-      'data': {}
-    }
-    Code:
-    200: Login success.
-    400: Wrong campus or not found user.
-    302: Wrong password.
-    */
+  /// Logs in to the bus (vms) system.
+  ///
+  /// Throws:
+  /// - [AuthException] with [AuthFailureReason.invalidCredentials] on code 302.
+  /// - [AuthException] with [AuthFailureReason.wrongCampus] on code 400.
+  /// - [ServerException] on any other non-success code.
+  /// - [StateError] if username or password is not configured in [Helper].
+  ///
+  /// NKUST response codes:
+  /// - 200: Login success
+  /// - 302: Wrong password
+  /// - 400: Wrong campus or user not found
+  Future<Map<String, dynamic>> busLogin() async {
     if (Helper.username == null || Helper.password == null) {
-      throw 'NullThrownError';
+      throw StateError(
+        'BusHelper.busLogin: Helper.username/password not configured',
+      );
     }
 
     await loginPrepare();
@@ -196,11 +196,33 @@ class BusHelper with ReloginMixin implements BusProvider {
       options: Options(contentType: Headers.formUrlEncodedContentType),
     );
 
-    if (res.data!['code'] == 200 && res.data!['success'] == true) {
+    final Map<String, dynamic>? data = res.data;
+    final int? code = data?['code'] as int?;
+    final bool success = data?['success'] == true;
+
+    if (code == 200 && success) {
       isLogin = true;
       markReloginSuccess();
+      return data!;
     }
-    return res.data;
+
+    switch (code) {
+      case 302:
+        throw AuthException(
+          AuthFailureReason.invalidCredentials,
+          message: 'bus login: wrong password',
+        );
+      case 400:
+        throw AuthException(
+          AuthFailureReason.wrongCampus,
+          message: 'bus login: wrong campus or user not found',
+        );
+      default:
+        throw ServerException(
+          httpStatusCode: res.statusCode,
+          message: 'bus login: unexpected response code: $code',
+        );
+    }
   }
 
   /// Checks if a Bus API response indicates an expired session.

--- a/lib/api/exceptions/api_exception.dart
+++ b/lib/api/exceptions/api_exception.dart
@@ -105,6 +105,25 @@ final class NetworkException extends ApException {
 
   final DioExceptionType? dioType;
 
+  /// Whether [e] represents a transport-layer failure (no usable response
+  /// was received), as opposed to an HTTP-level error the server
+  /// actually produced. Callers short-circuit with [NetworkException.from]
+  /// on `true` instead of interpreting the failure as e.g. a captcha retry.
+  static bool isTransport(DioException e) {
+    switch (e.type) {
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.receiveTimeout:
+      case DioExceptionType.sendTimeout:
+      case DioExceptionType.connectionError:
+      case DioExceptionType.badCertificate:
+      case DioExceptionType.unknown:
+        return true;
+      case DioExceptionType.badResponse:
+      case DioExceptionType.cancel:
+        return false;
+    }
+  }
+
   @override
   String get typeName => 'NetworkException';
 }

--- a/lib/api/exceptions/api_exception.dart
+++ b/lib/api/exceptions/api_exception.dart
@@ -202,3 +202,37 @@ final class BusSessionExpiredException extends ApException {
   @override
   String get typeName => 'BusSessionExpiredException';
 }
+
+/// Feature not usable on the current platform/campus configuration
+/// (e.g. bus system on web, or a sub-system the user's campus doesn't
+/// have access to).
+final class PlatformUnsupportedException extends ApException {
+  const PlatformUnsupportedException({
+    super.message = 'feature not supported on this platform',
+  }) : super(statusCode: ApStatusCode.unknownError);
+
+  @override
+  String get typeName => 'PlatformUnsupportedException';
+}
+
+/// Translates the transport / HTTP failure captured by Dio into the
+/// appropriate [ApException] subtype so callers can use a single
+/// `on ApException catch` clause instead of handling DioException
+/// separately in every UI page.
+extension DioExceptionToApException on DioException {
+  ApException toApException() {
+    if (type == DioExceptionType.cancel) {
+      return const CancelledException(message: 'request cancelled');
+    }
+    if (NetworkException.isTransport(this)) {
+      return NetworkException.from(this);
+    }
+    // DioExceptionType.badResponse — server responded with a non-2xx.
+    return ServerException(
+      httpStatusCode: response?.statusCode,
+      message: message ?? 'server error',
+      cause: this,
+      causeStackTrace: stackTrace,
+    );
+  }
+}

--- a/lib/api/exceptions/api_exception.dart
+++ b/lib/api/exceptions/api_exception.dart
@@ -176,3 +176,29 @@ final class CancelledException extends ApException {
   @override
   String get typeName => 'CancelledException';
 }
+
+/// Server indicated the current session has expired and a re-login is
+/// required (e.g. WebAP login parser returns code 2, Bus system returns
+/// "未登入"). Usually caught and handled by [ReloginMixin.withAutoRelogin];
+/// only escapes to the UI when all relogin attempts have been exhausted.
+final class ApSessionExpiredException extends ApException {
+  const ApSessionExpiredException()
+      : super(
+          statusCode: ApStatusCode.apiExpire,
+          message: 'WebAP session expired (code 2)',
+        );
+
+  @override
+  String get typeName => 'ApSessionExpiredException';
+}
+
+/// Bus-system variant of [ApSessionExpiredException]. Kept distinct so
+/// [BusHelper] can match only its own session errors without accidentally
+/// reacting to WebAP's.
+final class BusSessionExpiredException extends ApException {
+  const BusSessionExpiredException(String message)
+      : super(statusCode: ApStatusCode.apiExpire, message: message);
+
+  @override
+  String get typeName => 'BusSessionExpiredException';
+}

--- a/lib/api/exceptions/api_exception.dart
+++ b/lib/api/exceptions/api_exception.dart
@@ -203,6 +203,33 @@ final class BusSessionExpiredException extends ApException {
   String get typeName => 'BusSessionExpiredException';
 }
 
+/// The current account does not have access to this feature (e.g. a
+/// non-student trying to use the bus / leave system). Distinct from
+/// [AuthException] because authentication succeeded — the server simply
+/// refuses to serve this particular account. Typically produced by
+/// helpers translating an HTTP 401 (bus) or 403 (leave) into a typed
+/// subtype.
+final class AccountNotSupportedException extends ApException {
+  const AccountNotSupportedException({
+    super.message = 'account not supported',
+  }) : super(statusCode: ApStatusCode.unknownError);
+
+  @override
+  String get typeName => 'AccountNotSupportedException';
+}
+
+/// The current campus does not support this feature (e.g. a campus
+/// without a shuttle bus trying to open the bus page). Translated from
+/// HTTP 403 on bus endpoints.
+final class CampusNotSupportedException extends ApException {
+  const CampusNotSupportedException({
+    super.message = 'campus not supported',
+  }) : super(statusCode: ApStatusCode.unknownError);
+
+  @override
+  String get typeName => 'CampusNotSupportedException';
+}
+
 /// Feature not usable on the current platform/campus configuration
 /// (e.g. bus system on web, or a sub-system the user's campus doesn't
 /// have access to).

--- a/lib/api/exceptions/api_exception.dart
+++ b/lib/api/exceptions/api_exception.dart
@@ -215,6 +215,22 @@ final class PlatformUnsupportedException extends ApException {
   String get typeName => 'PlatformUnsupportedException';
 }
 
+/// Catch-all for unexpected errors that aren't one of the modelled
+/// failure modes above — typically programmer bugs (TypeError,
+/// FormatException, StateError, plugin failures). Produced by
+/// `Helper._call` so UI layers can still rely on `on ApException catch`
+/// while the original exception is recorded to Crashlytics via [cause].
+final class UnknownException extends ApException {
+  const UnknownException({
+    super.message = 'unexpected error',
+    super.cause,
+    super.causeStackTrace,
+  }) : super(statusCode: ApStatusCode.unknownError);
+
+  @override
+  String get typeName => 'UnknownException';
+}
+
 /// Translates the transport / HTTP failure captured by Dio into the
 /// appropriate [ApException] subtype so callers can use a single
 /// `on ApException catch` clause instead of handling DioException

--- a/lib/api/exceptions/api_exception.dart
+++ b/lib/api/exceptions/api_exception.dart
@@ -1,0 +1,159 @@
+import 'package:dio/dio.dart';
+import 'package:nkust_ap/api/ap_status_code.dart';
+
+/// Root of the typed exception hierarchy for crawler / login flows.
+///
+/// All helpers that can fail should throw a subtype of [ApException] so UI
+/// layers can handle each failure mode with an appropriate message and
+/// recovery action, instead of relying on brittle status-code mapping or
+/// generic [Exception] instances.
+sealed class ApException implements Exception {
+  const ApException({
+    required this.statusCode,
+    this.message = '',
+    this.cause,
+    this.causeStackTrace,
+  });
+
+  /// App-internal status code (see [ApStatusCode]).
+  final int statusCode;
+
+  /// Human-readable diagnostic message (English, not user-facing —
+  /// use the `toLocalizedMessage` extension for UI text).
+  final String message;
+
+  /// Underlying error that triggered this exception, if any.
+  final Object? cause;
+  final StackTrace? causeStackTrace;
+
+  /// Concrete type name used by [toString]; override in each subtype so
+  /// `runtimeType` is avoided (minified builds rename it).
+  String get typeName;
+
+  @override
+  String toString() {
+    final String base = '$typeName($statusCode)';
+    if (message.isEmpty) return base;
+    return '$base: $message';
+  }
+}
+
+/// Why an authentication attempt failed.
+enum AuthFailureReason {
+  /// Wrong username or password, or account does not exist.
+  invalidCredentials,
+
+  /// Account has been locked after too many failed attempts.
+  tooManyAttempts,
+
+  /// Selected campus does not match the account (e.g. Bus 400 response).
+  wrongCampus,
+
+  /// Generic auth failure with no more specific reason known.
+  unknown,
+}
+
+/// Authentication failed (wrong credentials, locked account, etc.).
+///
+/// Distinct from [NetworkException] and [ServerException]: the request
+/// reached the server, parsed normally, and the server rejected the
+/// credentials.
+final class AuthException extends ApException {
+  AuthException(
+    this.reason, {
+    int? statusCode,
+    super.message = 'authentication failed',
+    super.cause,
+    super.causeStackTrace,
+  }) : super(statusCode: statusCode ?? _defaultCodeFor(reason));
+
+  final AuthFailureReason reason;
+
+  @override
+  String get typeName => 'AuthException';
+
+  static int _defaultCodeFor(AuthFailureReason reason) {
+    switch (reason) {
+      case AuthFailureReason.invalidCredentials:
+        return ApStatusCode.userDataError;
+      case AuthFailureReason.tooManyAttempts:
+        return ApStatusCode.passwordFiveTimesError;
+      case AuthFailureReason.wrongCampus:
+      case AuthFailureReason.unknown:
+        return ApStatusCode.unknownError;
+    }
+  }
+}
+
+/// Transport-level failure: DNS, timeout, connection reset, SSL, etc.
+/// The request could not be completed; no server response was received or
+/// the response was malformed at the transport layer.
+final class NetworkException extends ApException {
+  const NetworkException({
+    this.dioType,
+    super.message = 'network error',
+    super.cause,
+    super.causeStackTrace,
+  }) : super(statusCode: ApStatusCode.networkConnectFail);
+
+  factory NetworkException.from(DioException e) => NetworkException(
+        dioType: e.type,
+        message: e.message ?? 'network error',
+        cause: e,
+        causeStackTrace: e.stackTrace,
+      );
+
+  final DioExceptionType? dioType;
+
+  @override
+  String get typeName => 'NetworkException';
+}
+
+/// CAPTCHA could not be solved after the allowed attempts.
+/// Typically bubbles up from OCR segmentation errors or repeated rejection
+/// by the server.
+final class CaptchaException extends ApException {
+  const CaptchaException({
+    this.attempts = 1,
+    super.message = 'captcha solving failed',
+    super.cause,
+    super.causeStackTrace,
+  }) : super(statusCode: ApStatusCode.unknownError);
+
+  /// Number of captcha attempts that were exhausted.
+  final int attempts;
+
+  @override
+  String get typeName => 'CaptchaException';
+}
+
+/// Server returned an error response (500 / 503 / malformed HTML).
+/// Distinct from [NetworkException]: the round-trip succeeded but the
+/// server could not produce a usable response.
+final class ServerException extends ApException {
+  ServerException({
+    int? statusCode,
+    this.httpStatusCode,
+    super.message = 'server error',
+    super.cause,
+    super.causeStackTrace,
+  }) : super(statusCode: statusCode ?? ApStatusCode.schoolServerError);
+
+  /// Raw HTTP status if known (may differ from [statusCode] which is the
+  /// app-internal [ApStatusCode] mapping).
+  final int? httpStatusCode;
+
+  @override
+  String get typeName => 'ServerException';
+}
+
+/// The user cancelled the flow (e.g. closed the WebView login page, or
+/// dismissed a confirmation dialog).
+final class CancelledException extends ApException {
+  const CancelledException({
+    super.message = 'cancelled',
+  }) : super(statusCode: ApStatusCode.cancel);
+
+  @override
+  String get typeName => 'CancelledException';
+}

--- a/lib/api/exceptions/api_exception_l10n.dart
+++ b/lib/api/exceptions/api_exception_l10n.dart
@@ -44,6 +44,8 @@ extension ApExceptionL10n on ApException {
         return ap.tokenExpiredContent;
       case PlatformUnsupportedException():
         return ap.platformError;
+      case UnknownException():
+        return ap.unknownError;
     }
   }
 }

--- a/lib/api/exceptions/api_exception_l10n.dart
+++ b/lib/api/exceptions/api_exception_l10n.dart
@@ -44,6 +44,10 @@ extension ApExceptionL10n on ApException {
         return ap.tokenExpiredContent;
       case PlatformUnsupportedException():
         return ap.platformError;
+      case AccountNotSupportedException():
+        return ap.userNotSupport;
+      case CampusNotSupportedException():
+        return ap.campusNotSupport;
       case UnknownException():
         return ap.unknownError;
     }

--- a/lib/api/exceptions/api_exception_l10n.dart
+++ b/lib/api/exceptions/api_exception_l10n.dart
@@ -29,8 +29,13 @@ extension ApExceptionL10n on ApException {
       case CaptchaException():
         return ap.captchaError;
       case ServerException():
-        if (self.httpStatusCode == 503) return ap.schoolServerError;
-        if (self.httpStatusCode == 500) return ap.apiServerError;
+        // httpStatusCode is the raw HTTP status when known; statusCode is
+        // the app-internal mapping (ApStatusCode.apiServerError=500,
+        // schoolServerError=503) used when the helper only has a response
+        // code rather than a real HTTP status. They line up numerically,
+        // so fall through to whichever is populated.
+        final int code = self.httpStatusCode ?? self.statusCode;
+        if (code == 500) return ap.apiServerError;
         return ap.schoolServerError;
       case CancelledException():
         return ap.loginFail;

--- a/lib/api/exceptions/api_exception_l10n.dart
+++ b/lib/api/exceptions/api_exception_l10n.dart
@@ -1,0 +1,39 @@
+import 'package:ap_common/ap_common.dart';
+import 'package:flutter/widgets.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/l10n/l10n.dart';
+
+/// Maps a typed [ApException] to the best-fit user-facing message, pulling
+/// from both the shared [ApLocalizations] (ap_common) and the project's own
+/// [AppLocalizations] so project-specific strings such as
+/// `loginFailedFiveTimes` can be reached.
+extension ApExceptionL10n on ApException {
+  String toLocalizedMessage(BuildContext context) {
+    final ApLocalizations ap = ApLocalizations.of(context);
+    final AppLocalizations app = AppLocalizations.of(context);
+    final ApException self = this;
+    switch (self) {
+      case AuthException():
+        switch (self.reason) {
+          case AuthFailureReason.invalidCredentials:
+            return ap.loginFail;
+          case AuthFailureReason.tooManyAttempts:
+            return app.loginFailedFiveTimes;
+          case AuthFailureReason.wrongCampus:
+            return ap.campusNotSupport;
+          case AuthFailureReason.unknown:
+            return ap.somethingError;
+        }
+      case NetworkException():
+        return ap.noInternet;
+      case CaptchaException():
+        return ap.captchaError;
+      case ServerException():
+        if (self.httpStatusCode == 503) return ap.schoolServerError;
+        if (self.httpStatusCode == 500) return ap.apiServerError;
+        return ap.schoolServerError;
+      case CancelledException():
+        return ap.loginFail;
+    }
+  }
+}

--- a/lib/api/exceptions/api_exception_l10n.dart
+++ b/lib/api/exceptions/api_exception_l10n.dart
@@ -42,6 +42,8 @@ extension ApExceptionL10n on ApException {
         // Session expired after relogin retries were exhausted — prompt
         // the user to log in again instead of showing a cryptic auth code.
         return ap.tokenExpiredContent;
+      case PlatformUnsupportedException():
+        return ap.platformError;
     }
   }
 }

--- a/lib/api/exceptions/api_exception_l10n.dart
+++ b/lib/api/exceptions/api_exception_l10n.dart
@@ -29,13 +29,11 @@ extension ApExceptionL10n on ApException {
       case CaptchaException():
         return ap.captchaError;
       case ServerException():
-        // httpStatusCode is the raw HTTP status when known; statusCode is
-        // the app-internal mapping (ApStatusCode.apiServerError=500,
-        // schoolServerError=503) used when the helper only has a response
-        // code rather than a real HTTP status. They line up numerically,
-        // so fall through to whichever is populated.
-        final int code = self.httpStatusCode ?? self.statusCode;
-        if (code == 500) return ap.apiServerError;
+        // In the current crawler-only architecture there is no proxy API
+        // server — every 5xx response ultimately comes from the school
+        // system, so all server errors map to schoolServerError. The
+        // legacy apiServerError branch was only meaningful when the app
+        // still talked to a middle-tier API.
         return ap.schoolServerError;
       case CancelledException():
         return ap.loginFail;

--- a/lib/api/exceptions/api_exception_l10n.dart
+++ b/lib/api/exceptions/api_exception_l10n.dart
@@ -37,6 +37,11 @@ extension ApExceptionL10n on ApException {
         return ap.schoolServerError;
       case CancelledException():
         return ap.loginFail;
+      case ApSessionExpiredException():
+      case BusSessionExpiredException():
+        // Session expired after relogin retries were exhausted — prompt
+        // the user to log in again instead of showing a cryptic auth code.
+        return ap.tokenExpiredContent;
     }
   }
 }

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -409,7 +409,11 @@ class Helper {
   /// Runs a crawler-facing operation and normalises every escaping
   /// exception into an [ApException] subtype:
   ///
-  /// - [ApException] → rethrown as-is.
+  /// - [ApException] → rethrown as-is. High-signal subtypes
+  ///   ([ServerException], [CaptchaException]) are also logged to
+  ///   Crashlytics so regressions in the school system or captcha OCR
+  ///   stay visible; low-signal ones (user wrong password, network off,
+  ///   user cancellation) are not logged to avoid noise.
   /// - [DioException] → translated to the matching subtype (network /
   ///   server / cancelled) via [DioExceptionToApException].
   /// - Anything else (TypeError, FormatException, StateError, plugin
@@ -420,10 +424,13 @@ class Helper {
   Future<T> _call<T>(Future<T> Function() body) async {
     try {
       return await body();
-    } on ApException {
+    } on ApException catch (e, s) {
+      _maybeRecordApException(e, s);
       rethrow;
-    } on DioException catch (e) {
-      throw e.toApException();
+    } on DioException catch (e, s) {
+      final ApException translated = e.toApException();
+      _maybeRecordApException(translated, s);
+      throw translated;
     } catch (e, s) {
       CrashlyticsUtil.instance.recordError(e, s);
       throw UnknownException(
@@ -431,6 +438,16 @@ class Helper {
         cause: e,
         causeStackTrace: s,
       );
+    }
+  }
+
+  /// High-signal ApException subtypes go to Crashlytics so regressions in
+  /// the school system or captcha OCR stay visible. Low-signal ones
+  /// (wrong password, no internet, user cancellation) are skipped to
+  /// keep the dashboard usable.
+  void _maybeRecordApException(ApException e, StackTrace s) {
+    if (e is ServerException || e is CaptchaException) {
+      CrashlyticsUtil.instance.recordError(e, s, reason: e.typeName);
     }
   }
 

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -406,10 +406,17 @@ class Helper {
     });
   }
 
-  /// Runs a crawler-facing operation and normalises any raw [DioException]
-  /// that escapes into the appropriate [ApException] subtype, so UI layers
-  /// only need `on ApException catch` instead of handling DioException
-  /// separately. Helpers that already throw [ApException] are untouched.
+  /// Runs a crawler-facing operation and normalises every escaping
+  /// exception into an [ApException] subtype:
+  ///
+  /// - [ApException] → rethrown as-is.
+  /// - [DioException] → translated to the matching subtype (network /
+  ///   server / cancelled) via [DioExceptionToApException].
+  /// - Anything else (TypeError, FormatException, StateError, plugin
+  ///   failures…) → recorded to Crashlytics and wrapped as
+  ///   [UnknownException] so the UI's single `on ApException catch`
+  ///   clause can surface a user-visible "未知錯誤" message instead of
+  ///   the call silently disappearing.
   Future<T> _call<T>(Future<T> Function() body) async {
     try {
       return await body();
@@ -417,6 +424,13 @@ class Helper {
       rethrow;
     } on DioException catch (e) {
       throw e.toApException();
+    } catch (e, s) {
+      CrashlyticsUtil.instance.recordError(e, s);
+      throw UnknownException(
+        message: '${e.runtimeType}: $e',
+        cause: e,
+        causeStackTrace: s,
+      );
     }
   }
 

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -383,8 +383,10 @@ class Helper {
   }
 
   Future<Uint8List?> getUserPicture(String pictureUrl) async {
-    final provider = registry.resolve<UserInfoProvider>(selector?.userInfo);
-    return provider.getUserPicture(pictureUrl);
+    return _call(() async {
+      final provider = registry.resolve<UserInfoProvider>(selector?.userInfo);
+      return provider.getUserPicture(pictureUrl);
+    });
   }
 
   Future<SemesterData> getSemester() async {

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -453,6 +453,44 @@ class Helper {
     }
   }
 
+  /// Specialisation of [_call] for bus endpoints: translates the bus
+  /// system's HTTP status conventions into typed subtypes before the
+  /// outer [_call] sees them.
+  ///
+  /// - 401 → [AccountNotSupportedException] (non-student, blocked account).
+  /// - 403 → [CampusNotSupportedException] (campus without shuttle bus).
+  ///
+  /// These are user-facing states, not regressions, so they skip the
+  /// Crashlytics pathway in `_maybeRecordApException`.
+  Future<T> _busCall<T>(Future<T> Function() body) async {
+    return _call(() async {
+      try {
+        return await body();
+      } on DioException catch (e) {
+        final int? code = e.response?.statusCode;
+        if (code == 401) throw const AccountNotSupportedException();
+        if (code == 403) throw const CampusNotSupportedException();
+        rethrow;
+      }
+    });
+  }
+
+  /// Specialisation of [_call] for leave endpoints: maps the leave
+  /// system's HTTP 403 to [AccountNotSupportedException] (the only
+  /// business-semantic status we currently translate for leave).
+  Future<T> _leaveCall<T>(Future<T> Function() body) async {
+    return _call(() async {
+      try {
+        return await body();
+      } on DioException catch (e) {
+        if (e.response?.statusCode == 403) {
+          throw const AccountNotSupportedException();
+        }
+        rethrow;
+      }
+    });
+  }
+
   Future<ScoreData?> getScores({
     required Semester semester,
   }) async {
@@ -543,7 +581,7 @@ class Helper {
   Future<BusData> getBusTimeTables({
     required DateTime dateTime,
   }) async {
-    return _call(() async {
+    return _busCall(() async {
       if (!MobileNkustHelper.isSupport) {
         throw const PlatformUnsupportedException();
       }
@@ -553,15 +591,18 @@ class Helper {
       if (data.canReserve) {
         return data;
       }
+      // Business-rule failure (outside reservation window / full).
+      // Preserve the server's Chinese description but leave
+      // httpStatusCode null so the typed-subtype layer doesn't treat
+      // this like a real HTTP 403 "campus not supported".
       throw ServerException(
-        httpStatusCode: 403,
         message: data.description ?? 'bus not reservable',
       );
     });
   }
 
   Future<BusReservationsData> getBusReservations() async {
-    return _call(() async {
+    return _busCall(() async {
       if (!MobileNkustHelper.isSupport) {
         throw const PlatformUnsupportedException();
       }
@@ -575,7 +616,7 @@ class Helper {
   Future<BookingBusData> bookingBusReservation({
     required String busId,
   }) async {
-    return _call(() async {
+    return _busCall(() async {
       if (!MobileNkustHelper.isSupport) {
         throw const PlatformUnsupportedException();
       }
@@ -589,7 +630,7 @@ class Helper {
   Future<CancelBusData> cancelBusReservation({
     required String cancelKey,
   }) async {
-    return _call(() async {
+    return _busCall(() async {
       if (!MobileNkustHelper.isSupport) {
         throw const PlatformUnsupportedException();
       }
@@ -601,7 +642,7 @@ class Helper {
   }
 
   Future<BusViolationRecordsData> getBusViolationRecords() async {
-    return _call(() async {
+    return _busCall(() async {
       if (!MobileNkustHelper.isSupport) {
         throw const PlatformUnsupportedException();
       }
@@ -636,7 +677,7 @@ class Helper {
   Future<LeaveData> getLeaves({
     required Semester semester,
   }) async {
-    return _call(() async {
+    return _leaveCall(() async {
       final provider = registry.resolve<LeaveProvider>(null);
       return provider.getLeaves(
         year: semester.year,
@@ -654,7 +695,7 @@ class Helper {
   }
 
   Future<LeaveSubmitInfoData> getLeavesSubmitInfo() async {
-    return _call(() async {
+    return _leaveCall(() async {
       final provider = registry.resolve<LeaveProvider>(null);
       return provider.getSubmitInfo();
     });
@@ -664,7 +705,7 @@ class Helper {
     required LeaveSubmitData data,
     required XFile? image,
   }) async {
-    return _call(() async {
+    return _leaveCall(() async {
       final provider = registry.resolve<LeaveProvider>(null);
       return provider.submit(data, proofImage: image);
     });

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -588,6 +588,18 @@ class Helper {
     });
   }
 
+  Future<UserInfo> searchUsername({
+    required String rocId,
+    required DateTime birthday,
+  }) async {
+    return _call(() async {
+      return NKUSTHelper.instance.getUsername(
+        rocId: rocId,
+        birthday: birthday,
+      );
+    });
+  }
+
   Future<LeaveData> getLeaves({
     required Semester semester,
   }) async {
@@ -597,6 +609,14 @@ class Helper {
         year: semester.year,
         semester: semester.value,
       );
+    });
+  }
+
+  Future<Response<Uint8List>> getEnrollmentLetter(
+    EnrollmentLetterLang lang,
+  ) async {
+    return _call(() async {
+      return StdsysHelper.instance.getEnrollmentLetter(lang);
     });
   }
 

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -10,6 +10,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:nkust_ap/api/ap_helper.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
 import 'package:nkust_ap/api/bus_helper.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/leave_helper.dart';
 import 'package:nkust_ap/api/mobile_nkust_helper.dart';
 import 'package:nkust_ap/api/nkust_helper.dart';
@@ -231,18 +232,16 @@ class Helper {
     Helper.username = username.toUpperCase();
     Helper.password = password;
     LoginResponse? loginResponse;
-    if (selector?.login == ScraperSource.mobile) {
-      loginResponse = await WebApHelper.instance.login(
+    loginResponse = await _call(() async {
+      final LoginResponse? result = await WebApHelper.instance.login(
         username: username.toUpperCase(),
         password: password,
       );
-      await WebApHelper.instance.loginVms();
-    } else {
-      loginResponse = await WebApHelper.instance.login(
-        username: username.toUpperCase(),
-        password: password,
-      );
-    }
+      if (selector?.login == ScraperSource.mobile) {
+        await WebApHelper.instance.loginVms();
+      }
+      return result;
+    });
     if (loginResponse != null) {
       expireTime = loginResponse.expireTime;
       _sessionState = Authenticated(
@@ -370,15 +369,17 @@ class Helper {
   }
 
   Future<UserInfo> getUsersInfo() async {
-    final provider = registry.resolve<UserInfoProvider>(selector?.userInfo);
-    UserInfo data = await provider.getUserInfo();
-    reLoginCount = 0;
-    if (data.id.isEmpty) {
-      data = data.copyWith(
-        id: username!,
-      );
-    }
-    return data;
+    return _call(() async {
+      final provider = registry.resolve<UserInfoProvider>(selector?.userInfo);
+      UserInfo data = await provider.getUserInfo();
+      reLoginCount = 0;
+      if (data.id.isEmpty) {
+        data = data.copyWith(
+          id: username!,
+        );
+      }
+      return data;
+    });
   }
 
   Future<Uint8List?> getUserPicture(String pictureUrl) async {
@@ -387,71 +388,95 @@ class Helper {
   }
 
   Future<SemesterData> getSemester() async {
-    SemesterData? data;
-    log(selector?.semester.toString() ?? '');
-    if (selector?.semester == ScraperSource.remoteConfig) {
-      data = SemesterData.load();
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-    } else {
-      final provider = registry.resolve<SemesterProvider>(selector?.semester);
-      data = await provider.getSemesters();
+    return _call(() async {
+      SemesterData? data;
+      log(selector?.semester.toString() ?? '');
+      if (selector?.semester == ScraperSource.remoteConfig) {
+        data = SemesterData.load();
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      } else {
+        final provider = registry.resolve<SemesterProvider>(selector?.semester);
+        data = await provider.getSemesters();
+      }
+      reLoginCount = 0;
+      if (data == null) {
+        throw ServerException(message: 'empty semester data');
+      }
+      return data;
+    });
+  }
+
+  /// Runs a crawler-facing operation and normalises any raw [DioException]
+  /// that escapes into the appropriate [ApException] subtype, so UI layers
+  /// only need `on ApException catch` instead of handling DioException
+  /// separately. Helpers that already throw [ApException] are untouched.
+  Future<T> _call<T>(Future<T> Function() body) async {
+    try {
+      return await body();
+    } on ApException {
+      rethrow;
+    } on DioException catch (e) {
+      throw e.toApException();
     }
-    reLoginCount = 0;
-    if (data == null) {
-      throw GeneralResponse.unknownError();
-    }
-    return data;
   }
 
   Future<ScoreData?> getScores({
     required Semester semester,
   }) async {
-    log('Fetch(Score) ${selector?.score} '
-        '${semester.year} ${semester.code}');
-    final provider = registry.resolve<ScoreProvider>(selector?.score);
-    ScoreData? data = await provider.getScores(
-      year: semester.year,
-      semester: semester.value,
-    );
-    if (data != null && data.scores.isEmpty) data = null;
-    return data;
+    return _call(() async {
+      log('Fetch(Score) ${selector?.score} '
+          '${semester.year} ${semester.code}');
+      final provider = registry.resolve<ScoreProvider>(selector?.score);
+      ScoreData? data = await provider.getScores(
+        year: semester.year,
+        semester: semester.value,
+      );
+      if (data != null && data.scores.isEmpty) data = null;
+      return data;
+    });
   }
 
   Future<CourseData> getCourseTables({
     required Semester semester,
   }) async {
-    log('Fetch(CourseTable) ${selector?.course} '
-        '${semester.year} ${semester.code}');
-    final provider = registry.resolve<CourseProvider>(selector?.course);
-    final CourseData data = await provider.getCourseTable(
-      year: semester.year,
-      semester: semester.value,
-    );
-    if (data.courses.isNotEmpty) {
-      reLoginCount = 0;
-    }
-    return data;
+    return _call(() async {
+      log('Fetch(CourseTable) ${selector?.course} '
+          '${semester.year} ${semester.code}');
+      final provider = registry.resolve<CourseProvider>(selector?.course);
+      final CourseData data = await provider.getCourseTable(
+        year: semester.year,
+        semester: semester.value,
+      );
+      if (data.courses.isNotEmpty) {
+        reLoginCount = 0;
+      }
+      return data;
+    });
   }
 
   Future<RewardAndPenaltyData> getRewardAndPenalty({
     required Semester semester,
   }) async {
-    final RewardAndPenaltyData data =
-        await WebApHelper.instance.rewardAndPenalty(
-      semester.year,
-      semester.value,
-    );
-    reLoginCount = 0;
-    return data;
+    return _call(() async {
+      final RewardAndPenaltyData data =
+          await WebApHelper.instance.rewardAndPenalty(
+        semester.year,
+        semester.value,
+      );
+      reLoginCount = 0;
+      return data;
+    });
   }
 
   Future<MidtermAlertsData> getMidtermAlerts({
     required Semester semester,
   }) async {
-    return await WebApHelper.instance.midtermAlerts(
-      semester.year,
-      semester.value,
-    );
+    return _call(() async {
+      return WebApHelper.instance.midtermAlerts(
+        semester.year,
+        semester.value,
+      );
+    });
   }
 
   //1=建工/2=燕巢/3=第一/4=楠梓/5=旗津/6=東方
@@ -459,115 +484,137 @@ class Helper {
     required Semester semester,
     required int campusCode,
   }) async {
-    final RoomData data = await StdsysHelper.instance
-        .roomList('$campusCode', semester.year, semester.value);
-    reLoginCount = 0;
-    return data;
+    return _call(() async {
+      final RoomData data = await StdsysHelper.instance
+          .roomList('$campusCode', semester.year, semester.value);
+      reLoginCount = 0;
+      return data;
+    });
   }
 
   Future<CourseData> getRoomCourseTables({
     required String? roomId,
     required Semester semester,
   }) async {
-    final CourseData data = await StdsysHelper.instance.roomCourseTableQuery(
-      roomId,
-      semester.year,
-      semester.value,
-    );
-    reLoginCount = 0;
-    return data;
+    return _call(() async {
+      final CourseData data = await StdsysHelper.instance.roomCourseTableQuery(
+        roomId,
+        semester.year,
+        semester.value,
+      );
+      reLoginCount = 0;
+      return data;
+    });
   }
 
   Future<BusData> getBusTimeTables({
     required DateTime dateTime,
   }) async {
-    if (!MobileNkustHelper.isSupport) {
-      throw GeneralResponse.platformNotSupport();
-    }
-    final provider = registry.resolve<BusProvider>(null);
-    final BusData data = await provider.getTimeTable(dateTime: dateTime);
-    reLoginCount = 0;
-    if (data.canReserve) {
-      return data;
-    } else {
-      throw GeneralResponse(
-        statusCode: 403,
-        message: data.description!,
+    return _call(() async {
+      if (!MobileNkustHelper.isSupport) {
+        throw const PlatformUnsupportedException();
+      }
+      final provider = registry.resolve<BusProvider>(null);
+      final BusData data = await provider.getTimeTable(dateTime: dateTime);
+      reLoginCount = 0;
+      if (data.canReserve) {
+        return data;
+      }
+      throw ServerException(
+        httpStatusCode: 403,
+        message: data.description ?? 'bus not reservable',
       );
-    }
+    });
   }
 
   Future<BusReservationsData> getBusReservations() async {
-    if (!MobileNkustHelper.isSupport) {
-      throw GeneralResponse.platformNotSupport();
-    }
-    final provider = registry.resolve<BusProvider>(null);
-    final BusReservationsData data = await provider.getReservations();
-    reLoginCount = 0;
-    return data;
+    return _call(() async {
+      if (!MobileNkustHelper.isSupport) {
+        throw const PlatformUnsupportedException();
+      }
+      final provider = registry.resolve<BusProvider>(null);
+      final BusReservationsData data = await provider.getReservations();
+      reLoginCount = 0;
+      return data;
+    });
   }
 
   Future<BookingBusData> bookingBusReservation({
     required String busId,
   }) async {
-    if (!MobileNkustHelper.isSupport) {
-      throw GeneralResponse.platformNotSupport();
-    }
-    final provider = registry.resolve<BusProvider>(null);
-    final BookingBusData data = await provider.bookBus(busId: busId);
-    reLoginCount = 0;
-    return data;
+    return _call(() async {
+      if (!MobileNkustHelper.isSupport) {
+        throw const PlatformUnsupportedException();
+      }
+      final provider = registry.resolve<BusProvider>(null);
+      final BookingBusData data = await provider.bookBus(busId: busId);
+      reLoginCount = 0;
+      return data;
+    });
   }
 
   Future<CancelBusData> cancelBusReservation({
     required String cancelKey,
   }) async {
-    if (!MobileNkustHelper.isSupport) {
-      throw GeneralResponse.platformNotSupport();
-    }
-    final provider = registry.resolve<BusProvider>(null);
-    final CancelBusData data = await provider.cancelBus(busId: cancelKey);
-    reLoginCount = 0;
-    return data;
+    return _call(() async {
+      if (!MobileNkustHelper.isSupport) {
+        throw const PlatformUnsupportedException();
+      }
+      final provider = registry.resolve<BusProvider>(null);
+      final CancelBusData data = await provider.cancelBus(busId: cancelKey);
+      reLoginCount = 0;
+      return data;
+    });
   }
 
   Future<BusViolationRecordsData> getBusViolationRecords() async {
-    if (!MobileNkustHelper.isSupport) {
-      throw GeneralResponse.platformNotSupport();
-    }
-    final provider = registry.resolve<BusProvider>(null);
-    final BusViolationRecordsData data = await provider.getViolationRecords();
-    reLoginCount = 0;
-    return data;
+    return _call(() async {
+      if (!MobileNkustHelper.isSupport) {
+        throw const PlatformUnsupportedException();
+      }
+      final provider = registry.resolve<BusProvider>(null);
+      final BusViolationRecordsData data =
+          await provider.getViolationRecords();
+      reLoginCount = 0;
+      return data;
+    });
   }
 
   Future<NotificationsData> getNotifications({
     required int page,
   }) async {
-    return await NKUSTHelper.instance.getNotifications(page);
+    return _call(() async {
+      return NKUSTHelper.instance.getNotifications(page);
+    });
   }
 
   Future<LeaveData> getLeaves({
     required Semester semester,
   }) async {
-    final provider = registry.resolve<LeaveProvider>(null);
-    return await provider.getLeaves(
-      year: semester.year,
-      semester: semester.value,
-    );
+    return _call(() async {
+      final provider = registry.resolve<LeaveProvider>(null);
+      return provider.getLeaves(
+        year: semester.year,
+        semester: semester.value,
+      );
+    });
   }
 
   Future<LeaveSubmitInfoData> getLeavesSubmitInfo() async {
-    final provider = registry.resolve<LeaveProvider>(null);
-    return await provider.getSubmitInfo();
+    return _call(() async {
+      final provider = registry.resolve<LeaveProvider>(null);
+      return provider.getSubmitInfo();
+    });
   }
 
   Future<Response<dynamic>?> sendLeavesSubmit({
     required LeaveSubmitData data,
     required XFile? image,
   }) async {
-    final provider = registry.resolve<LeaveProvider>(null);
-    return await provider.submit(data, proofImage: image);
+    return _call(() async {
+      final provider = registry.resolve<LeaveProvider>(null);
+      return provider.submit(data, proofImage: image);
+    });
   }
 
   Future<LibraryInfo?> getLibraryInfo() async {

--- a/lib/api/leave_helper.dart
+++ b/lib/api/leave_helper.dart
@@ -121,13 +121,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
       final Response<dynamic> res = await dio.get('');
       return res.data == 'alive';
     } on DioException catch (e) {
-      final bool isTransport = e.type == DioExceptionType.connectionTimeout ||
-          e.type == DioExceptionType.receiveTimeout ||
-          e.type == DioExceptionType.sendTimeout ||
-          e.type == DioExceptionType.connectionError ||
-          e.type == DioExceptionType.badCertificate ||
-          e.type == DioExceptionType.unknown;
-      if (isTransport) {
+      if (NetworkException.isTransport(e)) {
         throw NetworkException.from(e);
       }
       // Non-transport DioException (badResponse etc.) indicates the server

--- a/lib/api/leave_helper.dart
+++ b/lib/api/leave_helper.dart
@@ -12,6 +12,7 @@ import 'package:nkust_ap/api/api_config.dart';
 import 'package:nkust_ap/api/ap_helper.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
 import 'package:nkust_ap/api/capability/leave_provider.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/relogin_mixin.dart';
 import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/api/parser/leave_parser.dart';
@@ -106,13 +107,32 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
     );
   }
 
+  /// Probes whether the current cookies still authenticate us to the
+  /// leave system.
+  ///
+  /// - Returns `true`  → session alive.
+  /// - Returns `false` → session absent / expired but server reachable.
+  /// - Throws [NetworkException] when the probe itself cannot reach the
+  ///   server (timeout, DNS, etc.) — caller should distinguish this from
+  ///   a real logged-out state.
   Future<bool> isCookieAlive() async {
     try {
       //TODO check cookies is expire
       final Response<dynamic> res = await dio.get('');
       return res.data == 'alive';
-    } catch (_) {}
-    return false;
+    } on DioException catch (e) {
+      final bool isTransport = e.type == DioExceptionType.connectionTimeout ||
+          e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout ||
+          e.type == DioExceptionType.connectionError ||
+          e.type == DioExceptionType.unknown;
+      if (isTransport) {
+        throw NetworkException.from(e);
+      }
+      // Non-transport DioException (badResponse etc.) indicates the server
+      // answered but not with 'alive' — treat as logged out.
+      return false;
+    }
   }
 
   Future<LoginResponse> login({
@@ -154,7 +174,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
       markReloginSuccess();
       return LoginResponse();
     } else {
-      throw GeneralResponse(statusCode: ApStatusCode.cancel, message: 'cancel');
+      throw const CancelledException(message: 'leave login cancelled by user');
     }
   }
 
@@ -163,7 +183,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
   )
   Future<bool> leaveLogin() async {
     if (Helper.username == null || Helper.password == null) {
-      throw 'NullThrownError';
+      throw StateError('Helper.username/password not configured');
     }
 
     //Get base hidden data.
@@ -202,7 +222,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
   Future<LeaveData> getLeaves(
       {required String year, required String semester}) async {
     if (Helper.username == null || Helper.password == null) {
-      throw 'NullThrownError';
+      throw StateError('Helper.username/password not configured');
     }
     if (!(isLogin ?? false)) {
       await _webApHelper.loginToLeave();
@@ -229,7 +249,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
 
   Future<LeaveSubmitInfoData> getLeavesSubmitInfo() async {
     if (Helper.username == null || Helper.password == null) {
-      throw 'NullThrownError';
+      throw StateError('Helper.username/password not configured');
     }
     if (!(isLogin ?? false)) {
       await _webApHelper.loginToLeave();

--- a/lib/api/leave_helper.dart
+++ b/lib/api/leave_helper.dart
@@ -125,6 +125,7 @@ class LeaveHelper with ReloginMixin implements LeaveProvider {
           e.type == DioExceptionType.receiveTimeout ||
           e.type == DioExceptionType.sendTimeout ||
           e.type == DioExceptionType.connectionError ||
+          e.type == DioExceptionType.badCertificate ||
           e.type == DioExceptionType.unknown;
       if (isTransport) {
         throw NetworkException.from(e);

--- a/lib/api/mobile_nkust_helper.dart
+++ b/lib/api/mobile_nkust_helper.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:nkust_ap/api/ap_helper.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/api_config.dart';
 import 'package:nkust_ap/api/parser/mobile_nkust_parser.dart';
 import 'package:nkust_ap/config/constants.dart';
@@ -256,7 +257,9 @@ class MobileNkustHelper
       return LoginResponse();
     }
 
-    throw GeneralResponse(statusCode: ApStatusCode.cancel, message: 'cancel');
+    throw const CancelledException(
+      message: 'mobile.nkust login cancelled by user',
+    );
   }
 
   @override

--- a/lib/api/nkust_helper.dart
+++ b/lib/api/nkust_helper.dart
@@ -134,6 +134,28 @@ class NKUSTHelper {
         }
       } on ApException {
         rethrow;
+      } on SocketException catch (e, s) {
+        // package:http wraps transport errors as SocketException /
+        // HandshakeException; translate immediately so the UI shows
+        // "沒有網路連線" rather than the generic "未知錯誤" that _call
+        // would otherwise wrap this as.
+        throw NetworkException(
+          message: e.message,
+          cause: e,
+          causeStackTrace: s,
+        );
+      } on HandshakeException catch (e, s) {
+        throw NetworkException(
+          message: e.message,
+          cause: e,
+          causeStackTrace: s,
+        );
+      } on http.ClientException catch (e, s) {
+        throw NetworkException(
+          message: e.message,
+          cause: e,
+          causeStackTrace: s,
+        );
       } catch (error) {
         lastError = error;
 

--- a/lib/api/nkust_helper.dart
+++ b/lib/api/nkust_helper.dart
@@ -12,6 +12,7 @@ import 'package:http/http.dart' as http;
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:nkust_ap/api/api_config.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/parser/nkust_parser.dart';
 import 'package:nkust_ap/config/constants.dart';
 import 'package:nkust_ap/utils/captcha_utils.dart';
@@ -121,14 +122,18 @@ class NKUSTHelper {
             );
             return userInfo;
           } else if (elements.length == 1) {
-            throw GeneralResponse(
-              statusCode: 404,
+            throw ServerException(
+              httpStatusCode: 404,
               message: elements[0].text,
             );
           } else {
-            throw GeneralResponse.unknownError();
+            throw ServerException(
+              message: 'unexpected element count in username lookup response',
+            );
           }
         }
+      } on ApException {
+        rethrow;
       } catch (error) {
         lastError = error;
 
@@ -138,11 +143,11 @@ class NKUSTHelper {
       }
     }
 
-    throw GeneralResponse(
-      statusCode: ApStatusCode.unknownError,
+    throw CaptchaException(
+      attempts: retryCounts,
       message: lastError == null
-          ? 'captcha error or unknown error'
-          : 'captcha error or unknown error: $lastError',
+          ? 'captcha failed after $retryCounts attempts'
+          : 'captcha failed: $lastError',
     );
   }
 
@@ -177,6 +182,8 @@ class NKUSTHelper {
         });
       }
     }
-    throw GeneralResponse.unknownError();
+    throw ServerException(
+      message: 'notifications request returned no usable response',
+    );
   }
 }

--- a/lib/api/relogin_mixin.dart
+++ b/lib/api/relogin_mixin.dart
@@ -141,22 +141,7 @@ mixin ReloginMixin {
   }
 }
 
-/// Exception thrown when WebAP `apQuery` detects a session-expired response
-/// (login parser returns code 2).
-class ApSessionExpiredException implements Exception {
-  const ApSessionExpiredException();
-
-  @override
-  String toString() =>
-      'ApSessionExpiredException: WebAP session expired (code 2)';
-}
-
-/// Exception thrown when the Bus system returns a "未登入" (not logged in)
-/// response.
-class BusSessionExpiredException implements Exception {
-  final String message;
-  const BusSessionExpiredException(this.message);
-
-  @override
-  String toString() => 'BusSessionExpiredException: $message';
-}
+// ApSessionExpiredException / BusSessionExpiredException have been folded
+// into the ApException hierarchy in lib/api/exceptions/api_exception.dart
+// so UI layers that catch `on ApException catch` automatically cover the
+// session-expired case when relogin retries are exhausted.

--- a/lib/pages/bus/bus_page.dart
+++ b/lib/pages/bus/bus_page.dart
@@ -153,8 +153,8 @@ class BusPageState extends State<BusPage> with SingleTickerProviderStateMixin {
             : AnalyticsConstants.no,
       );
     } on ApException catch (e) {
-      if (e is ServerException &&
-          (e.httpStatusCode == 401 || e.httpStatusCode == 403)) {
+      if (e is AccountNotSupportedException ||
+          e is CampusNotSupportedException) {
         AnalyticsUtil.instance.setUserProperty(
           Constants.canUseBus,
           AnalyticsConstants.no,

--- a/lib/pages/bus/bus_page.dart
+++ b/lib/pages/bus/bus_page.dart
@@ -1,6 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
 import 'package:nkust_ap/api/ap_helper.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/mobile_nkust_helper.dart';
 import 'package:nkust_ap/models/bus_violation_records_data.dart';
 import 'package:nkust_ap/pages/bus/bus_rule_page.dart';
@@ -151,9 +152,9 @@ class BusPageState extends State<BusPage> with SingleTickerProviderStateMixin {
             ? AnalyticsConstants.yes
             : AnalyticsConstants.no,
       );
-    } on DioException catch (e) {
-      if (e.hasResponse &&
-          (e.response!.statusCode == 401 || e.response!.statusCode == 403)) {
+    } on ApException catch (e) {
+      if (e is ServerException &&
+          (e.httpStatusCode == 401 || e.httpStatusCode == 403)) {
         AnalyticsUtil.instance.setUserProperty(
           Constants.canUseBus,
           AnalyticsConstants.no,

--- a/lib/pages/bus/bus_reservations_page.dart
+++ b/lib/pages/bus/bus_reservations_page.dart
@@ -246,64 +246,42 @@ class BusReservationsPageState extends State<BusReservationsPage>
       );
       busReservationsData?.save(Helper.username);
     } on ApException catch (e) {
-      if (mounted) {
+      if (e is CancelledException) return;
+      if (!mounted) return;
+      // Map specific bus-system HTTP statuses to dedicated states so
+      // users see the right "not supported" hint for campus/account.
+      if (e is ServerException) {
+        switch (e.httpStatusCode) {
+          case 401:
+            setState(() => state = _State.userNotSupport);
+            AnalyticsUtil.instance.setUserProperty(
+              Constants.canUseBus,
+              AnalyticsConstants.no,
+            );
+          case 403:
+            setState(() => state = _State.campusNotSupport);
+            AnalyticsUtil.instance.setUserProperty(
+              Constants.canUseBus,
+              AnalyticsConstants.no,
+            );
+          default:
+            setState(() {
+              state = _State.custom;
+              customStateHint = e.toLocalizedMessage(context);
+            });
+            if (e.httpStatusCode != null) {
+              AnalyticsUtil.instance.logApiEvent(
+                'getBusReservations',
+                e.httpStatusCode!,
+                message: e.message,
+              );
+            }
+        }
+      } else {
         setState(() {
           state = _State.custom;
           customStateHint = e.toLocalizedMessage(context);
         });
-      }
-      _loadCache();
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        setState(() {
-          state = _State.custom;
-          customStateHint = response.getGeneralMessage(context);
-        });
-      }
-      _loadCache();
-    } on DioException catch (e) {
-      if (mounted) {
-        switch (e.type) {
-          case DioExceptionType.badResponse:
-            setState(() {
-              if (e.response!.statusCode == 401) {
-                state = _State.userNotSupport;
-              } else if (e.response!.statusCode == 403) {
-                state = _State.campusNotSupport;
-              } else {
-                state = _State.custom;
-                customStateHint = e.message;
-                AnalyticsUtil.instance.logApiEvent(
-                  'getBusReservations',
-                  e.response!.statusCode!,
-                  message: e.message ?? '',
-                );
-              }
-            });
-            if (e.response!.statusCode == 401 ||
-                e.response!.statusCode == 403) {
-              AnalyticsUtil.instance.setUserProperty(
-                Constants.canUseBus,
-                AnalyticsConstants.no,
-              );
-            }
-          case DioExceptionType.unknown:
-            setState(() {
-              if (e.message?.contains('HttpException') ?? false) {
-                state = _State.custom;
-                customStateHint = app!.busFailInfinity;
-              } else {
-                state = _State.error;
-              }
-            });
-          case DioExceptionType.cancel:
-            break;
-          default:
-            setState(() {
-              state = _State.custom;
-              customStateHint = e.i18nMessage;
-            });
-        }
       }
       _loadCache();
     }
@@ -390,22 +368,10 @@ class BusReservationsPageState extends State<BusReservationsPage>
         ),
       );
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      BusReservePageState.handleGeneralError(
-        context,
-        response,
-        app!.busCancelReserveFail,
-      );
-    } on DioException catch (e) {
-      BusReservePageState.handleDioError(
-        context,
-        e,
-        app!.busCancelReserveFail,
-        'cancel_bus',
-      );
     }
   }
 

--- a/lib/pages/bus/bus_reservations_page.dart
+++ b/lib/pages/bus/bus_reservations_page.dart
@@ -1,5 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/models/models.dart';
 import 'package:nkust_ap/utils/global.dart';
 
@@ -243,6 +245,14 @@ class BusReservationsPageState extends State<BusReservationsPage>
         AnalyticsConstants.yes,
       );
       busReservationsData?.save(Helper.username);
+    } on ApException catch (e) {
+      if (mounted) {
+        setState(() {
+          state = _State.custom;
+          customStateHint = e.toLocalizedMessage(context);
+        });
+      }
+      _loadCache();
     } on GeneralResponse catch (response) {
       if (mounted) {
         setState(() {
@@ -379,6 +389,10 @@ class BusReservationsPageState extends State<BusReservationsPage>
               Navigator.of(context, rootNavigator: true).pop(),
         ),
       );
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       BusReservePageState.handleGeneralError(
         context,

--- a/lib/pages/bus/bus_reservations_page.dart
+++ b/lib/pages/bus/bus_reservations_page.dart
@@ -248,40 +248,30 @@ class BusReservationsPageState extends State<BusReservationsPage>
     } on ApException catch (e) {
       if (e is CancelledException) return;
       if (!mounted) return;
-      // Map specific bus-system HTTP statuses to dedicated states so
-      // users see the right "not supported" hint for campus/account.
-      if (e is ServerException) {
-        switch (e.httpStatusCode) {
-          case 401:
-            setState(() => state = _State.userNotSupport);
-            AnalyticsUtil.instance.setUserProperty(
-              Constants.canUseBus,
-              AnalyticsConstants.no,
-            );
-          case 403:
-            setState(() => state = _State.campusNotSupport);
-            AnalyticsUtil.instance.setUserProperty(
-              Constants.canUseBus,
-              AnalyticsConstants.no,
-            );
-          default:
-            setState(() {
-              state = _State.custom;
-              customStateHint = e.toLocalizedMessage(context);
-            });
-            if (e.httpStatusCode != null) {
-              AnalyticsUtil.instance.logApiEvent(
-                'getBusReservations',
-                e.httpStatusCode!,
-                message: e.message,
-              );
-            }
-        }
+      if (e is AccountNotSupportedException) {
+        setState(() => state = _State.userNotSupport);
+        AnalyticsUtil.instance.setUserProperty(
+          Constants.canUseBus,
+          AnalyticsConstants.no,
+        );
+      } else if (e is CampusNotSupportedException) {
+        setState(() => state = _State.campusNotSupport);
+        AnalyticsUtil.instance.setUserProperty(
+          Constants.canUseBus,
+          AnalyticsConstants.no,
+        );
       } else {
         setState(() {
           state = _State.custom;
           customStateHint = e.toLocalizedMessage(context);
         });
+        if (e is ServerException && e.httpStatusCode != null) {
+          AnalyticsUtil.instance.logApiEvent(
+            'getBusReservations',
+            e.httpStatusCode!,
+            message: e.message,
+          );
+        }
       }
       _loadCache();
     }

--- a/lib/pages/bus/bus_reserve_page.dart
+++ b/lib/pages/bus/bus_reserve_page.dart
@@ -348,42 +348,37 @@ class BusReservePageState extends State<BusReservePage>
     } on ApException catch (e) {
       if (e is CancelledException) return;
       if (!mounted) return;
-      if (e is ServerException) {
-        switch (e.httpStatusCode) {
-          case 401:
-            setState(() => state = _State.userNotSupport);
-            AnalyticsUtil.instance.setUserProperty(
-              Constants.canUseBus,
-              AnalyticsConstants.no,
-            );
-          case 403:
-            setState(() {
-              state = _State.custom;
-              // Bus "cannot reserve" business rule keeps the raw server
-              // message (e.g. reservation window closed); other 403s fall
-              // back to the generic campus-unsupported hint.
-              customStateHint = e.message.isNotEmpty
-                  ? e.message
-                  : e.toLocalizedMessage(context);
-            });
-          default:
-            setState(() {
-              state = _State.custom;
-              customStateHint = e.toLocalizedMessage(context);
-            });
-            if (e.httpStatusCode != null) {
-              AnalyticsUtil.instance.logApiEvent(
-                'getBusTimeTables',
-                e.httpStatusCode!,
-                message: e.message,
-              );
-            }
-        }
+      if (e is AccountNotSupportedException) {
+        setState(() => state = _State.userNotSupport);
+        AnalyticsUtil.instance.setUserProperty(
+          Constants.canUseBus,
+          AnalyticsConstants.no,
+        );
+      } else if (e is CampusNotSupportedException) {
+        setState(() => state = _State.campusNotSupport);
+        AnalyticsUtil.instance.setUserProperty(
+          Constants.canUseBus,
+          AnalyticsConstants.no,
+        );
+      } else if (e is ServerException && e.message.isNotEmpty) {
+        // Bus "cannot reserve" business rule keeps the raw server
+        // message (e.g. reservation window closed / train full).
+        setState(() {
+          state = _State.custom;
+          customStateHint = e.message;
+        });
       } else {
         setState(() {
           state = _State.custom;
           customStateHint = e.toLocalizedMessage(context);
         });
+        if (e is ServerException && e.httpStatusCode != null) {
+          AnalyticsUtil.instance.logApiEvent(
+            'getBusTimeTables',
+            e.httpStatusCode!,
+            message: e.message,
+          );
+        }
       }
     }
   }

--- a/lib/pages/bus/bus_reserve_page.dart
+++ b/lib/pages/bus/bus_reserve_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
-import 'package:nkust_ap/models/error_response.dart';
 import 'package:nkust_ap/models/models.dart';
 import 'package:nkust_ap/utils/global.dart';
 import 'package:nkust_ap/widgets/flutter_calendar.dart';

--- a/lib/pages/bus/bus_reserve_page.dart
+++ b/lib/pages/bus/bus_reserve_page.dart
@@ -347,62 +347,44 @@ class BusReservePageState extends State<BusReservePage>
         AnalyticsConstants.yes,
       );
     } on ApException catch (e) {
-      setState(() {
-        state = _State.custom;
-        customStateHint = e.toLocalizedMessage(context);
-      });
-    } on GeneralResponse catch (response) {
-      setState(() {
-        state = _State.custom;
-        if (response.statusCode == 403) {
-          customStateHint = response.message;
-        } else {
-          customStateHint = response.getGeneralMessage(context);
-        }
-      });
-    } on DioException catch (e) {
-      if (mounted) {
-        switch (e.type) {
-          case DioExceptionType.badResponse:
+      if (e is CancelledException) return;
+      if (!mounted) return;
+      if (e is ServerException) {
+        switch (e.httpStatusCode) {
+          case 401:
+            setState(() => state = _State.userNotSupport);
+            AnalyticsUtil.instance.setUserProperty(
+              Constants.canUseBus,
+              AnalyticsConstants.no,
+            );
+          case 403:
             setState(() {
-              if (e.response!.statusCode == 401) {
-                state = _State.userNotSupport;
-              } else if (e.response!.statusCode == 403) {
-                state = _State.campusNotSupport;
-              } else {
-                state = _State.custom;
-                customStateHint = e.message;
-                AnalyticsUtil.instance.logApiEvent(
-                  'getBusTimeTables',
-                  e.response!.statusCode!,
-                  message: e.message ?? '',
-                );
-              }
+              state = _State.custom;
+              // Bus "cannot reserve" business rule keeps the raw server
+              // message (e.g. reservation window closed); other 403s fall
+              // back to the generic campus-unsupported hint.
+              customStateHint = e.message.isNotEmpty
+                  ? e.message
+                  : e.toLocalizedMessage(context);
             });
-            if (e.response!.statusCode == 401 ||
-                e.response!.statusCode == 403) {
-              AnalyticsUtil.instance.setUserProperty(
-                Constants.canUseBus,
-                AnalyticsConstants.no,
-              );
-            }
-          case DioExceptionType.unknown:
-            setState(() {
-              if (e.message?.contains('HttpException') ?? false) {
-                state = _State.custom;
-                customStateHint = app!.busFailInfinity;
-              } else {
-                state = _State.error;
-              }
-            });
-          case DioExceptionType.cancel:
-            break;
           default:
             setState(() {
               state = _State.custom;
-              customStateHint = e.i18nMessage;
+              customStateHint = e.toLocalizedMessage(context);
             });
+            if (e.httpStatusCode != null) {
+              AnalyticsUtil.instance.logApiEvent(
+                'getBusTimeTables',
+                e.httpStatusCode!,
+                message: e.message,
+              );
+            }
         }
+      } else {
+        setState(() {
+          state = _State.custom;
+          customStateHint = e.toLocalizedMessage(context);
+        });
       }
     }
   }
@@ -554,13 +536,11 @@ class BusReservePageState extends State<BusReservePage>
         ),
       );
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
+        Navigator.of(context, rootNavigator: true).pop();
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      handleGeneralError(context, response, app!.busReserveFailTitle);
-    } on DioException catch (e) {
-      handleDioError(context, e, app!.busReserveFailTitle, 'book_bus');
     }
   }
 
@@ -624,13 +604,11 @@ class BusReservePageState extends State<BusReservePage>
         ),
       );
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
+        Navigator.of(context, rootNavigator: true).pop();
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      handleGeneralError(context, response, app!.busCancelReserveFail);
-    } on DioException catch (e) {
-      handleDioError(context, e, app!.busCancelReserveFail, 'cancel_bus');
     }
   }
 
@@ -642,55 +620,4 @@ class BusReservePageState extends State<BusReservePage>
     } catch (_) {}
   }
 
-  static void handleGeneralError(
-    BuildContext context,
-    GeneralResponse response,
-    String title,
-  ) {
-    Navigator.of(context, rootNavigator: true).pop();
-    DialogUtils.showDefault(
-      context: context,
-      title: title,
-      content: response.getGeneralMessage(context),
-    );
-  }
-
-  static void handleDioError(
-    BuildContext context,
-    DioException e,
-    String title,
-    String tag,
-  ) {
-    Navigator.of(context, rootNavigator: true).pop();
-    String? message;
-    switch (e.type) {
-      case DioExceptionType.badResponse:
-        final ErrorResponse errorResponse =
-            ErrorResponse.fromJson(e.response!.data as Map<String, dynamic>);
-        message = errorResponse.description;
-        AnalyticsUtil.instance.logEvent(
-          tag,
-          parameters: <String, String>{
-            'message': errorResponse.description,
-          },
-        );
-      case DioExceptionType.unknown:
-        if (e.message?.contains('HttpException') ?? false) {
-          message = AppLocalizations.of(context).busFailInfinity;
-        } else {
-          message = context.ap.somethingError;
-        }
-      case DioExceptionType.cancel:
-        break;
-      default:
-        message = e.i18nMessage;
-    }
-    if (message != null) {
-      DialogUtils.showDefault(
-        context: context,
-        title: title,
-        content: message,
-      );
-    }
-  }
 }

--- a/lib/pages/bus/bus_reserve_page.dart
+++ b/lib/pages/bus/bus_reserve_page.dart
@@ -1,6 +1,8 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/models/error_response.dart';
 import 'package:nkust_ap/models/models.dart';
 import 'package:nkust_ap/utils/global.dart';
@@ -344,6 +346,11 @@ class BusReservePageState extends State<BusReservePage>
         Constants.canUseBus,
         AnalyticsConstants.yes,
       );
+    } on ApException catch (e) {
+      setState(() {
+        state = _State.custom;
+        customStateHint = e.toLocalizedMessage(context);
+      });
     } on GeneralResponse catch (response) {
       setState(() {
         state = _State.custom;
@@ -546,6 +553,10 @@ class BusReservePageState extends State<BusReservePage>
           },
         ),
       );
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       handleGeneralError(context, response, app!.busReserveFailTitle);
     } on DioException catch (e) {
@@ -612,6 +623,10 @@ class BusReservePageState extends State<BusReservePage>
               Navigator.of(context, rootNavigator: true).pop(),
         ),
       );
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       handleGeneralError(context, response, app!.busCancelReserveFail);
     } on DioException catch (e) {

--- a/lib/pages/bus/bus_violation_records_page.dart
+++ b/lib/pages/bus/bus_violation_records_page.dart
@@ -246,38 +246,30 @@ class _BusViolationRecordsPageState extends State<BusViolationRecordsPage> {
     } on ApException catch (e) {
       if (e is CancelledException) return;
       if (!mounted) return;
-      if (e is ServerException) {
-        switch (e.httpStatusCode) {
-          case 401:
-            setState(() => state = _State.userNotSupport);
-            AnalyticsUtil.instance.setUserProperty(
-              Constants.canUseBus,
-              AnalyticsConstants.no,
-            );
-          case 403:
-            setState(() => state = _State.campusNotSupport);
-            AnalyticsUtil.instance.setUserProperty(
-              Constants.canUseBus,
-              AnalyticsConstants.no,
-            );
-          default:
-            setState(() {
-              state = _State.custom;
-              customStateHint = e.toLocalizedMessage(context);
-            });
-            if (e.httpStatusCode != null) {
-              AnalyticsUtil.instance.logApiEvent(
-                'getBusViolationRecords',
-                e.httpStatusCode!,
-                message: e.message,
-              );
-            }
-        }
+      if (e is AccountNotSupportedException) {
+        setState(() => state = _State.userNotSupport);
+        AnalyticsUtil.instance.setUserProperty(
+          Constants.canUseBus,
+          AnalyticsConstants.no,
+        );
+      } else if (e is CampusNotSupportedException) {
+        setState(() => state = _State.campusNotSupport);
+        AnalyticsUtil.instance.setUserProperty(
+          Constants.canUseBus,
+          AnalyticsConstants.no,
+        );
       } else {
         setState(() {
           state = _State.custom;
           customStateHint = e.toLocalizedMessage(context);
         });
+        if (e is ServerException && e.httpStatusCode != null) {
+          AnalyticsUtil.instance.logApiEvent(
+            'getBusViolationRecords',
+            e.httpStatusCode!,
+            message: e.message,
+          );
+        }
       }
     }
   }

--- a/lib/pages/bus/bus_violation_records_page.dart
+++ b/lib/pages/bus/bus_violation_records_page.dart
@@ -1,5 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/config/constants.dart';
 import 'package:nkust_ap/models/bus_violation_records_data.dart';
@@ -241,54 +243,41 @@ class _BusViolationRecordsPageState extends State<BusViolationRecordsPage> {
             ? AnalyticsConstants.yes
             : AnalyticsConstants.no,
       );
-    } on GeneralResponse catch (response) {
-      setState(() {
-        state = _State.custom;
-        customStateHint = response.getGeneralMessage(context);
-      });
-    } on DioException catch (e) {
-      if (mounted) {
-        switch (e.type) {
-          case DioExceptionType.badResponse:
-            setState(() {
-              if (e.response!.statusCode == 401) {
-                state = _State.userNotSupport;
-              } else if (e.response!.statusCode == 403) {
-                state = _State.campusNotSupport;
-              } else {
-                state = _State.custom;
-                customStateHint = e.message;
-                AnalyticsUtil.instance.logApiEvent(
-                  'getBusViolationRecords',
-                  e.response!.statusCode!,
-                  message: e.message ?? '',
-                );
-              }
-            });
-            if (e.response!.statusCode == 401 ||
-                e.response!.statusCode == 403) {
-              AnalyticsUtil.instance.setUserProperty(
-                Constants.canUseBus,
-                AnalyticsConstants.no,
-              );
-            }
-          case DioExceptionType.unknown:
-            setState(() {
-              if (e.message?.contains('HttpException') ?? false) {
-                state = _State.custom;
-                customStateHint = app.busFailInfinity;
-              } else {
-                state = _State.error;
-              }
-            });
-          case DioExceptionType.cancel:
-            break;
+    } on ApException catch (e) {
+      if (e is CancelledException) return;
+      if (!mounted) return;
+      if (e is ServerException) {
+        switch (e.httpStatusCode) {
+          case 401:
+            setState(() => state = _State.userNotSupport);
+            AnalyticsUtil.instance.setUserProperty(
+              Constants.canUseBus,
+              AnalyticsConstants.no,
+            );
+          case 403:
+            setState(() => state = _State.campusNotSupport);
+            AnalyticsUtil.instance.setUserProperty(
+              Constants.canUseBus,
+              AnalyticsConstants.no,
+            );
           default:
             setState(() {
               state = _State.custom;
-              customStateHint = e.i18nMessage;
+              customStateHint = e.toLocalizedMessage(context);
             });
+            if (e.httpStatusCode != null) {
+              AnalyticsUtil.instance.logApiEvent(
+                'getBusViolationRecords',
+                e.httpStatusCode!,
+                message: e.message,
+              );
+            }
         }
+      } else {
+        setState(() {
+          state = _State.custom;
+          customStateHint = e.toLocalizedMessage(context);
+        });
       }
     }
   }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -680,12 +680,12 @@ class HomePageState extends State<HomePage> {
       if (PreferenceUtil.instance.getBool(Constants.prefBusNotify, false)) {
         await Utils.setBusNotify(context, response.reservations);
       }
-    } on DioException catch (e) {
-      if (e.hasResponse) {
+    } on ApException catch (e) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getBusReservations',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     } catch (e, s) {
@@ -720,13 +720,13 @@ class HomePageState extends State<HomePage> {
             _getUserPicture();
           }
         }
-      } on DioException catch (e) {
+      } on ApException catch (e) {
         _userInfoFetchFailed = true;
-        if (e.hasResponse) {
+        if (e is ServerException && e.httpStatusCode != null) {
           AnalyticsUtil.instance.logApiEvent(
             'getUserInfo',
-            e.response!.statusCode!,
-            message: e.message ?? '',
+            e.httpStatusCode!,
+            message: e.message,
           );
         }
       } catch (e, s) {
@@ -804,6 +804,7 @@ class HomePageState extends State<HomePage> {
         ..showBasicHint(text: ap.loginSuccess);
     } on ApException catch (e) {
       if (isLogin) return;
+      if (e is CancelledException) return;
       // Invalid credentials / account lockout — stop auto-login; user must
       // re-enter password.
       if (e is AuthException &&
@@ -820,15 +821,6 @@ class HomePageState extends State<HomePage> {
         );
         offLineLogin();
       }
-    } on DioException catch (e) {
-      if (isLogin) return;
-      final String text = e.i18nMessage!;
-      _homeKey.currentState!.showSnackBar(
-        text: text,
-        actionText: ap.retry,
-        onSnackBarTapped: _login,
-      );
-      offLineLogin();
     }
   }
 

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -12,6 +12,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/api/leave_helper.dart';
 import 'package:nkust_ap/api/mobile_nkust_helper.dart';
 import 'package:nkust_ap/api/scraper_registry.dart';
@@ -800,28 +802,19 @@ class HomePageState extends State<HomePage> {
       _homeKey.currentState
         ?..hideSnackBar()
         ..showBasicHint(text: ap.loginSuccess);
-    } on GeneralResponse catch (response) {
+    } on ApException catch (e) {
       if (isLogin) return;
-      String message = '';
-      if (response.statusCode == ApStatusCode.userDataError ||
-          response.statusCode == ApStatusCode.passwordFiveTimesError) {
-        Toast.show(ap.passwordError, context);
+      // Invalid credentials / account lockout — stop auto-login; user must
+      // re-enter password.
+      if (e is AuthException &&
+          (e.reason == AuthFailureReason.invalidCredentials ||
+              e.reason == AuthFailureReason.tooManyAttempts)) {
+        Toast.show(e.toLocalizedMessage(context), context);
         await PreferenceUtil.instance.setBool(Constants.prefAutoLogin, false);
         checkLogin();
       } else {
-        switch (response.statusCode) {
-          case ApStatusCode.schoolServerError:
-            message = ap.schoolServerError;
-          case ApStatusCode.apiServerError:
-            message = ap.apiServerError;
-          case ApStatusCode.unknownError:
-          case ApStatusCode.cancel:
-            message = ap.loginFail;
-          default:
-            message = ap.somethingError;
-        }
         _homeKey.currentState!.showSnackBar(
-          text: message,
+          text: e.toLocalizedMessage(context),
           actionText: ap.retry,
           onSnackBarTapped: _login,
         );

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -739,19 +739,13 @@ class HomePageState extends State<HomePage> {
   }
 
   Future<void> _getUserPicture() async {
-    try {
-      if (userInfo != null && userInfo!.pictureUrl != null) {
-        final Uint8List? response =
-            await Helper.instance.getUserPicture(userInfo!.pictureUrl!);
-        if (mounted) {
-          setState(() {
-            userInfo = userInfo!.copyWith(pictureBytes: response);
-          });
-        }
-        // CacheUtils.savePictureData(response);
-      }
-    } catch (e) {
-      rethrow;
+    if (userInfo == null || userInfo!.pictureUrl == null) return;
+    final Uint8List? response =
+        await Helper.instance.getUserPicture(userInfo!.pictureUrl!);
+    if (mounted) {
+      setState(() {
+        userInfo = userInfo!.copyWith(pictureBytes: response);
+      });
     }
   }
 

--- a/lib/pages/info/shcool_info_page.dart
+++ b/lib/pages/info/shcool_info_page.dart
@@ -5,6 +5,8 @@ import 'package:ap_common/ap_common.dart';
 import 'package:ap_common_firebase/ap_common_firebase.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/utils/global.dart';
 
 class SchoolInfoPage extends StatefulWidget {
@@ -160,15 +162,9 @@ class SchoolInfoPageState extends State<SchoolInfoPage>
         if (mounted) {
           setState(() => notificationState = NotificationState.finish);
         }
-      } on GeneralResponse {
-        UiUtil.instance.showToast(context, ap.somethingError);
-        if (mounted && notificationList.isEmpty) {
-          setState(() => notificationState = NotificationState.error);
-        }
-      } on DioException catch (e) {
-        if (e.i18nMessage != null) {
-          UiUtil.instance.showToast(context, e.i18nMessage!);
-        }
+      } on ApException catch (e) {
+        if (e is CancelledException) return;
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
         if (mounted && notificationList.isEmpty) {
           setState(() => notificationState = NotificationState.error);
         }

--- a/lib/pages/leave/leave_apply_page.dart
+++ b/lib/pages/leave/leave_apply_page.dart
@@ -511,7 +511,7 @@ class LeaveApplyPageState extends State<LeaveApplyPage>
       });
     } on ApException catch (e) {
       if (e is CancelledException) return;
-      if (e is ServerException && e.httpStatusCode == 403) {
+      if (e is AccountNotSupportedException) {
         setState(() => state = _State.userNotSupport);
       } else {
         setState(() {

--- a/lib/pages/leave/leave_apply_page.dart
+++ b/lib/pages/leave/leave_apply_page.dart
@@ -5,6 +5,8 @@ import 'package:ap_common/ap_common.dart';
 import 'package:ap_common_firebase/ap_common_firebase.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/models/error_response.dart';
 import 'package:nkust_ap/models/leave_campus_data.dart';
 import 'package:nkust_ap/models/leave_submit_data.dart';
@@ -507,6 +509,12 @@ class LeaveApplyPageState extends State<LeaveApplyPage>
         leaveSubmitInfo = data;
         state = _State.finish;
       });
+    } on ApException catch (e) {
+      setState(() {
+        state = _State.custom;
+        customStateHint = e.toLocalizedMessage(context);
+      });
+      AnalyticsUtil.instance.logEvent('get_submit_submit_fail');
     } on GeneralResponse catch (response) {
       setState(() {
         state = _State.custom;
@@ -717,6 +725,14 @@ class LeaveApplyPageState extends State<LeaveApplyPage>
             res?.statusCode == 200 ? ap.leaveSubmitSuccess : '${res?.data}',
       );
       AnalyticsUtil.instance.logEvent('leave_submit_success');
+    } on ApException catch (e) {
+      Navigator.of(context, rootNavigator: true).pop();
+      DialogUtils.showDefault(
+        context: context,
+        title: ap.leaveSubmitFail,
+        content: e.toLocalizedMessage(context),
+      );
+      AnalyticsUtil.instance.logEvent('leave_submit_fail');
     } on GeneralResponse catch (response) {
       Navigator.of(context, rootNavigator: true).pop();
       DialogUtils.showDefault(

--- a/lib/pages/leave/leave_apply_page.dart
+++ b/lib/pages/leave/leave_apply_page.dart
@@ -510,43 +510,20 @@ class LeaveApplyPageState extends State<LeaveApplyPage>
         state = _State.finish;
       });
     } on ApException catch (e) {
-      setState(() {
-        state = _State.custom;
-        customStateHint = e.toLocalizedMessage(context);
-      });
-      AnalyticsUtil.instance.logEvent('get_submit_submit_fail');
-    } on GeneralResponse catch (response) {
-      setState(() {
-        state = _State.custom;
-        customStateHint = response.getGeneralMessage(context);
-      });
-      AnalyticsUtil.instance.logEvent('get_submit_submit_fail');
-    } on DioException catch (e) {
-      if (mounted) {
-        switch (e.type) {
-          case DioExceptionType.badResponse:
-            setState(() {
-              if (e.response!.statusCode == 403) {
-                state = _State.userNotSupport;
-              } else {
-                state = _State.custom;
-                customStateHint = e.message;
-                AnalyticsUtil.instance.logApiEvent(
-                  'getLeaveSubmitInfo',
-                  e.response!.statusCode!,
-                  message: e.message ?? '',
-                );
-              }
-            });
-          case DioExceptionType.unknown:
-            setState(() => state = _State.error);
-          case DioExceptionType.cancel:
-            break;
-          default:
-            setState(() {
-              state = _State.custom;
-              customStateHint = e.i18nMessage;
-            });
+      if (e is CancelledException) return;
+      if (e is ServerException && e.httpStatusCode == 403) {
+        setState(() => state = _State.userNotSupport);
+      } else {
+        setState(() {
+          state = _State.custom;
+          customStateHint = e.toLocalizedMessage(context);
+        });
+        if (e is ServerException && e.httpStatusCode != null) {
+          AnalyticsUtil.instance.logApiEvent(
+            'getLeaveSubmitInfo',
+            e.httpStatusCode!,
+            message: e.message,
+          );
         }
       }
       AnalyticsUtil.instance.logEvent('get_submit_submit_fail');
@@ -726,47 +703,25 @@ class LeaveApplyPageState extends State<LeaveApplyPage>
       );
       AnalyticsUtil.instance.logEvent('leave_submit_success');
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       Navigator.of(context, rootNavigator: true).pop();
+      // When the leave submit returns a badResponse with a JSON body,
+      // surface the server-provided description instead of the generic
+      // localized string.
+      String content = e.toLocalizedMessage(context);
+      if (e is ServerException && e.cause is DioException) {
+        final DioException inner = e.cause! as DioException;
+        if (inner.response?.data is Map<String, dynamic>) {
+          content = ErrorResponse.fromJson(
+            inner.response!.data as Map<String, dynamic>,
+          ).description;
+        }
+      }
       DialogUtils.showDefault(
         context: context,
         title: ap.leaveSubmitFail,
-        content: e.toLocalizedMessage(context),
+        content: content,
       );
-      AnalyticsUtil.instance.logEvent('leave_submit_fail');
-    } on GeneralResponse catch (response) {
-      Navigator.of(context, rootNavigator: true).pop();
-      DialogUtils.showDefault(
-        context: context,
-        title: ap.leaveSubmitFail,
-        content: response.getGeneralMessage(context),
-      );
-      AnalyticsUtil.instance.logEvent('leave_submit_fail');
-    } on DioException catch (e) {
-      Navigator.of(context, rootNavigator: true).pop();
-      String? text;
-      switch (e.type) {
-        case DioExceptionType.badResponse:
-          if (e.response!.data is Map<String, dynamic>) {
-            text = ErrorResponse.fromJson(
-              e.response!.data as Map<String, dynamic>,
-            ).description;
-          } else {
-            text = ap.somethingError;
-          }
-        case DioExceptionType.unknown:
-          text = ap.somethingError;
-        case DioExceptionType.cancel:
-          break;
-        default:
-          text = e.i18nMessage;
-      }
-      if (text != null) {
-        DialogUtils.showDefault(
-          context: context,
-          title: ap.leaveSubmitFail,
-          content: text,
-        );
-      }
       AnalyticsUtil.instance.logEvent('leave_submit_fail');
     }
   }

--- a/lib/pages/leave/leave_record_page.dart
+++ b/lib/pages/leave/leave_record_page.dart
@@ -2,6 +2,8 @@ import 'dart:developer';
 
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/models/leave_data.dart';
 import 'package:nkust_ap/utils/global.dart';
 
@@ -394,6 +396,10 @@ class LeaveRecordPageState extends State<LeaveRecordPage>
         });
         _getSemesterLeaveRecord();
       }
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       if (mounted) {
         UiUtil.instance.showToast(context, response.getGeneralMessage(context));
@@ -433,6 +439,15 @@ class LeaveRecordPageState extends State<LeaveRecordPage>
       }
       log(state.toString());
       leaveData!.save(selectSemester!.cacheSaveTag);
+    } on ApException catch (e) {
+      if (mounted) {
+        _pickerController.markSemesterHasData(selectSemester!);
+      }
+      setState(() {
+        state = _State.custom;
+        customStateHint = e.toLocalizedMessage(context);
+      });
+      _loadOfflineLeaveData();
     } on GeneralResponse catch (response) {
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);

--- a/lib/pages/leave/leave_record_page.dart
+++ b/lib/pages/leave/leave_record_page.dart
@@ -397,22 +397,15 @@ class LeaveRecordPageState extends State<LeaveRecordPage>
         _getSemesterLeaveRecord();
       }
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        UiUtil.instance.showToast(context, response.getGeneralMessage(context));
-      }
-    } on DioException catch (e) {
-      if (e.i18nMessage != null && mounted) {
-        UiUtil.instance.showToast(context, e.i18nMessage!);
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getSemester',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }
@@ -440,6 +433,7 @@ class LeaveRecordPageState extends State<LeaveRecordPage>
       log(state.toString());
       leaveData!.save(selectSemester!.cacheSaveTag);
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);
       }
@@ -447,29 +441,11 @@ class LeaveRecordPageState extends State<LeaveRecordPage>
         state = _State.custom;
         customStateHint = e.toLocalizedMessage(context);
       });
-      _loadOfflineLeaveData();
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      setState(() {
-        state = _State.custom;
-        customStateHint = response.getGeneralMessage(context);
-      });
-      _loadOfflineLeaveData();
-    } on DioException catch (e) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      setState(() {
-        state = _State.custom;
-        customStateHint = e.i18nMessage;
-      });
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getSemesterLeaveRecord',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
       _loadOfflineLeaveData();

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -2,6 +2,8 @@ import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/pages/search_student_id_page.dart';
 import 'package:nkust_ap/res/assets.dart';
 import 'package:nkust_ap/utils/global.dart';
@@ -207,24 +209,12 @@ class LoginPageState extends State<LoginPage> {
         PreferenceUtil.instance.setBool(Constants.prefIsOfflineLogin, false);
         TextInput.finishAutofillContext();
         Navigator.of(context).pop(true);
-      } on GeneralResponse catch (response) {
-        String? message;
-        switch (response.statusCode) {
-          case ApStatusCode.schoolServerError:
-            message = ap.schoolServerError;
-          case ApStatusCode.apiServerError:
-            message = ap.apiServerError;
-          case ApStatusCode.userDataError:
-            message = ap.loginFail;
-          case ApStatusCode.passwordFiveTimesError:
-            //TODO i18n
-            message = '您先前已登入失敗達5次!!請30分鐘後再嘗試登入!!';
-          case ApStatusCode.cancel:
-            message = null;
-          default:
-            message = ap.somethingError;
+      } on ApException catch (e) {
+        // Silently dismiss user-initiated cancellations (e.g. closing the
+        // leave-system WebView); any other failure gets a user-visible toast.
+        if (e is! CancelledException) {
+          UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
         }
-        if (message != null) UiUtil.instance.showToast(context, message);
         setState(() => isLoginIng = false);
       } on DioException catch (e) {
         if (e.i18nMessage != null) {

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -219,12 +219,6 @@ class LoginPageState extends State<LoginPage> {
         // Offer offline mode on network failure so the user isn't stuck
         // on a blocked login screen when their connection drops.
         if (e is NetworkException) _offlineLogin();
-      } on DioException catch (e) {
-        if (e.i18nMessage != null) {
-          UiUtil.instance.showToast(context, e.i18nMessage!);
-        }
-        setState(() => isLoginIng = false);
-        if (e.type != DioExceptionType.cancel) _offlineLogin();
       }
     }
   }

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -216,6 +216,9 @@ class LoginPageState extends State<LoginPage> {
           UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
         }
         setState(() => isLoginIng = false);
+        // Offer offline mode on network failure so the user isn't stuck
+        // on a blocked login screen when their connection drops.
+        if (e is NetworkException) _offlineLogin();
       } on DioException catch (e) {
         if (e.i18nMessage != null) {
           UiUtil.instance.showToast(context, e.i18nMessage!);

--- a/lib/pages/search_student_id_page.dart
+++ b/lib/pages/search_student_id_page.dart
@@ -1,6 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
-import 'package:nkust_ap/api/nkust_helper.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/res/assets.dart';
 import 'package:nkust_ap/utils/global.dart';
 import 'package:sprintf/sprintf.dart';
@@ -161,7 +162,7 @@ class SearchStudentIdPageState extends State<SearchStudentIdPage> {
     AnalyticsUtil.instance.logEvent('search_username_click');
 
     try {
-      final UserInfo data = await NKUSTHelper.instance.getUsername(
+      final UserInfo data = await Helper.instance.searchUsername(
         rocId: _id.text,
         birthday: birthday,
       );
@@ -177,15 +178,17 @@ class SearchStudentIdPageState extends State<SearchStudentIdPage> {
           ),
         );
       }
-    } on GeneralResponse catch (response) {
+    } on ApException catch (e) {
       if (!mounted) return;
       setState(() => isSearching = false);
+      if (e is CancelledException) return;
+      // 404 means "no match found" — surface the server's own message
+      // (e.g. "查無此人") instead of the generic ap.unknownError.
+      final bool isNotFound = e is ServerException && e.httpStatusCode == 404;
       _showResultDialog(
-        response.statusCode == 404 ? response.message : context.ap.unknownError,
+        isNotFound ? e.message : context.ap.unknownError,
         showFirstHint: false,
       );
-    } on DioException catch (_) {
-      if (mounted) setState(() => isSearching = false);
     }
   }
 

--- a/lib/pages/setting_page.dart
+++ b/lib/pages/setting_page.dart
@@ -257,19 +257,13 @@ class SettingPageState extends State<SettingPage> {
       Navigator.of(context, rootNavigator: true).pop();
       setState(() => busNotify = false);
       PreferenceUtil.instance.setBool(Constants.prefBusNotify, busNotify);
-      if (e is ServerException && e.httpStatusCode == 401) {
-        UiUtil.instance.showToast(context, ap.userNotSupport);
-      } else if (e is ServerException && e.httpStatusCode == 403) {
-        UiUtil.instance.showToast(context, ap.campusNotSupport);
-      } else {
-        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
-        if (e is ServerException && e.httpStatusCode != null) {
-          AnalyticsUtil.instance.logApiEvent(
-            'getBusReservations',
-            e.httpStatusCode!,
-            message: e.message,
-          );
-        }
+      UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      if (e is ServerException && e.httpStatusCode != null) {
+        AnalyticsUtil.instance.logApiEvent(
+          'getBusReservations',
+          e.httpStatusCode!,
+          message: e.message,
+        );
       }
     }
   }

--- a/lib/pages/setting_page.dart
+++ b/lib/pages/setting_page.dart
@@ -3,6 +3,8 @@ import 'package:ap_common_flutter_ui/ap_common_flutter_ui.dart';
 import 'package:ap_common_plugin/ap_common_plugin.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/models/bus_reservations_data.dart';
 import 'package:nkust_ap/utils/global.dart';
 import 'package:nkust_ap/widgets/share_data_widget.dart';
@@ -250,35 +252,23 @@ class SettingPageState extends State<SettingPage> {
         );
       }
       PreferenceUtil.instance.setBool(Constants.prefBusNotify, busNotify);
-    } on GeneralResponse catch (response) {
+    } on ApException catch (e) {
+      if (e is CancelledException) return;
       Navigator.of(context, rootNavigator: true).pop();
       setState(() => busNotify = false);
       PreferenceUtil.instance.setBool(Constants.prefBusNotify, busNotify);
-      UiUtil.instance.showToast(context, response.getGeneralMessage(context));
-    } on DioException catch (e) {
-      Navigator.of(context, rootNavigator: true).pop();
-      setState(() => busNotify = false);
-      PreferenceUtil.instance.setBool(Constants.prefBusNotify, busNotify);
-      if (e.hasResponse) {
-        if (e.response!.statusCode == 401) {
-          UiUtil.instance.showToast(context, ap.userNotSupport);
-        } else if (e.response!.statusCode == 403) {
-          UiUtil.instance.showToast(context, ap.campusNotSupport);
-        } else {
-          if (e.message != null) {
-            UiUtil.instance.showToast(context, e.message!);
-            AnalyticsUtil.instance.logApiEvent(
-              'getBusReservations',
-              e.response!.statusCode!,
-              message: e.message ?? '',
-            );
-          }
-        }
-      } else if (e.type == DioExceptionType.unknown) {
-        UiUtil.instance.showToast(context, ap.busFailInfinity);
+      if (e is ServerException && e.httpStatusCode == 401) {
+        UiUtil.instance.showToast(context, ap.userNotSupport);
+      } else if (e is ServerException && e.httpStatusCode == 403) {
+        UiUtil.instance.showToast(context, ap.campusNotSupport);
       } else {
-        if (e.i18nMessage != null) {
-          UiUtil.instance.showToast(context, e.i18nMessage!);
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+        if (e is ServerException && e.httpStatusCode != null) {
+          AnalyticsUtil.instance.logApiEvent(
+            'getBusReservations',
+            e.httpStatusCode!,
+            message: e.message,
+          );
         }
       }
     }

--- a/lib/pages/study/calculate_units_page.dart
+++ b/lib/pages/study/calculate_units_page.dart
@@ -1,6 +1,8 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:ap_common_firebase/ap_common_firebase.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/utils/global.dart';
 
 enum _State {
@@ -286,17 +288,11 @@ class CalculateUnitsPageState extends State<CalculateUnitsPage>
     _getSemesterScore();
   }
 
-  void _onFailure(DioException e) {
+  void _onError(ApException e) {
+    if (e is CancelledException) return;
     setState(() {
       state = _State.custom;
-      customStateHint = e.i18nMessage;
-    });
-  }
-
-  void _onError(GeneralResponse response) {
-    setState(() {
-      state = _State.custom;
-      customStateHint = response.getGeneralMessage(context);
+      customStateHint = e.toLocalizedMessage(context);
     });
   }
 
@@ -309,10 +305,8 @@ class CalculateUnitsPageState extends State<CalculateUnitsPage>
     }
     try {
       semesterData = await Helper.instance.getSemester();
-    } on GeneralResponse catch (response) {
-      _onError(response);
-    } on DioException catch (e) {
-      _onFailure(e);
+    } on ApException catch (e) {
+      _onError(e);
     }
   }
 
@@ -378,10 +372,8 @@ class CalculateUnitsPageState extends State<CalculateUnitsPage>
           });
         }
       }
-    } on GeneralResponse catch (response) {
-      _onError(response);
-    } on DioException catch (e) {
-      _onFailure(e);
+    } on ApException catch (e) {
+      _onError(e);
     }
   }
 }

--- a/lib/pages/study/course_page.dart
+++ b/lib/pages/study/course_page.dart
@@ -147,9 +147,11 @@ class CoursePageState extends State<CoursePage> {
           _apiCourseData = cacheData;
           _customCourseData = CustomCourseData.load(courseNotifyCacheKey);
           courseData = cacheData.mergeCustom(_customCourseData.courses);
-          state = courseData.courses.isEmpty
-              ? CourseState.empty
-              : CourseState.finish;
+          // Any non-null cache (even if courses list is empty) maps to
+          // `finish` so the offline view renders an empty course grid
+          // rather than the `empty` error state which hides the table.
+          // Matches ScorePage's _loadOfflineScoreData behaviour.
+          state = CourseState.finish;
           notifyData = CourseNotifyData.load(courseNotifyCacheKey);
         }
       });
@@ -166,7 +168,12 @@ class CoursePageState extends State<CoursePage> {
       );
       if (mounted) {
         _apiCourseData = data;
-        data.save(selectSemester!.cacheSaveTag);
+        // Only persist non-empty course data so a bad fetch (parser
+        // hiccup / transient empty response) doesn't overwrite a
+        // previously-working offline copy with nothing.
+        if (data.courses.isNotEmpty) {
+          data.save(selectSemester!.cacheSaveTag);
+        }
         _customCourseData = CustomCourseData.load(courseNotifyCacheKey);
         courseData = data.mergeCustom(_customCourseData.courses);
         setState(() {

--- a/lib/pages/study/course_page.dart
+++ b/lib/pages/study/course_page.dart
@@ -122,22 +122,15 @@ class CoursePageState extends State<CoursePage> {
         _getCourseTables();
       }
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        UiUtil.instance.showToast(context, response.getGeneralMessage(context));
-      }
-    } on DioException catch (e) {
-      if (e.i18nMessage != null && mounted) {
-        UiUtil.instance.showToast(context, e.i18nMessage!);
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getSemester',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }
@@ -195,38 +188,18 @@ class CoursePageState extends State<CoursePage> {
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);
       }
-      if (await _loadCacheData(selectSemester!.code)) {
+      if (await _loadCacheData(selectSemester!.code) &&
+          e is! CancelledException) {
         setState(() {
           state = CourseState.custom;
           customStateHint = e.toLocalizedMessage(context);
         });
       }
-    } on GeneralResponse catch (generalResponse) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      if (await _loadCacheData(selectSemester!.code)) {
-        setState(() {
-          state = CourseState.custom;
-          customStateHint = generalResponse.getGeneralMessage(context);
-        });
-      }
-    } on DioException catch (e) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      if (await _loadCacheData(selectSemester!.code) &&
-          e.type != DioExceptionType.cancel) {
-        setState(() {
-          state = CourseState.custom;
-          customStateHint = e.i18nMessage;
-        });
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getCourseTables',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }

--- a/lib/pages/study/course_page.dart
+++ b/lib/pages/study/course_page.dart
@@ -1,6 +1,8 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:ap_common_plugin/ap_common_plugin.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/utils/global.dart';
 
 class CoursePage extends StatefulWidget {
@@ -119,6 +121,10 @@ class CoursePageState extends State<CoursePage> {
         _loadCacheData(selectSemester!.code);
         _getCourseTables();
       }
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       if (mounted) {
         UiUtil.instance.showToast(context, response.getGeneralMessage(context));
@@ -184,6 +190,16 @@ class CoursePageState extends State<CoursePage> {
         if (courseData.courses.isNotEmpty) {
           await ApCommonPlugin.updateCourseWidget(courseData);
         }
+      }
+    } on ApException catch (e) {
+      if (mounted) {
+        _pickerController.markSemesterHasData(selectSemester!);
+      }
+      if (await _loadCacheData(selectSemester!.code)) {
+        setState(() {
+          state = CourseState.custom;
+          customStateHint = e.toLocalizedMessage(context);
+        });
       }
     } on GeneralResponse catch (generalResponse) {
       if (mounted) {

--- a/lib/pages/study/enrollment_letter_page.dart
+++ b/lib/pages/study/enrollment_letter_page.dart
@@ -4,6 +4,8 @@ import 'dart:typed_data';
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
 import 'package:nkust_ap/api/ap_helper.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/api/stdsys_helper.dart';
 import 'package:nkust_ap/utils/global.dart';
 
@@ -120,6 +122,11 @@ class _EnrollmentLetterPageState extends State<EnrollmentLetterPage> {
       setState(() {
         pdfState = PdfState.finish;
         data = responseData;
+      });
+    } on ApException catch (e) {
+      setState(() {
+        pdfState = PdfState.error;
+        errorMessage = e.toLocalizedMessage(context);
       });
     } on GeneralResponse catch (e) {
       setState(() {

--- a/lib/pages/study/enrollment_letter_page.dart
+++ b/lib/pages/study/enrollment_letter_page.dart
@@ -96,7 +96,7 @@ class _EnrollmentLetterPageState extends State<EnrollmentLetterPage> {
   Future<void> _getEnrollmentLetter() async {
     try {
       final Response<Uint8List> response =
-          await StdsysHelper.instance.getEnrollmentLetter(selectedLang);
+          await Helper.instance.getEnrollmentLetter(selectedLang);
       final responseData = response.data;
       if (responseData == null || responseData.isEmpty) {
         setState(() {

--- a/lib/pages/study/enrollment_letter_page.dart
+++ b/lib/pages/study/enrollment_letter_page.dart
@@ -135,11 +135,6 @@ class _EnrollmentLetterPageState extends State<EnrollmentLetterPage> {
           errorMessage = e.toLocalizedMessage(context);
         }
       });
-    } catch (e) {
-      setState(() {
-        pdfState = PdfState.error;
-        errorMessage = app.loadFailed.replaceAll('%s', e.toString());
-      });
     }
   }
 }

--- a/lib/pages/study/enrollment_letter_page.dart
+++ b/lib/pages/study/enrollment_letter_page.dart
@@ -124,21 +124,16 @@ class _EnrollmentLetterPageState extends State<EnrollmentLetterPage> {
         data = responseData;
       });
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       setState(() {
         pdfState = PdfState.error;
-        errorMessage = e.toLocalizedMessage(context);
-      });
-    } on GeneralResponse catch (e) {
-      setState(() {
-        pdfState = PdfState.error;
-        errorMessage = e.message;
-      });
-    } on DioException catch (e) {
-      setState(() {
-        pdfState = PdfState.error;
-        errorMessage = e.response?.statusCode == 404
-            ? app.noEnrollmentData
-            : app.networkError.replaceAll('%s', e.message ?? '');
+        // Keep the 404 special case (no enrollment letter available for
+        // this student) mapped to a dedicated user message.
+        if (e is ServerException && e.httpStatusCode == 404) {
+          errorMessage = app.noEnrollmentData;
+        } else {
+          errorMessage = e.toLocalizedMessage(context);
+        }
       });
     } catch (e) {
       setState(() {

--- a/lib/pages/study/midterm_alerts_page.dart
+++ b/lib/pages/study/midterm_alerts_page.dart
@@ -1,5 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/models/midterm_alerts_data.dart';
 import 'package:nkust_ap/utils/global.dart';
 
@@ -244,6 +246,10 @@ class _MidtermAlertsPageState extends State<MidtermAlertsPage> {
         });
         _getMidtermAlertsData();
       }
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       if (mounted) {
         UiUtil.instance.showToast(context, response.getGeneralMessage(context));
@@ -287,6 +293,14 @@ class _MidtermAlertsPageState extends State<MidtermAlertsPage> {
           }
         });
       }
+    } on ApException catch (e) {
+      if (mounted) {
+        _pickerController.markSemesterHasData(selectSemester!);
+      }
+      setState(() {
+        state = _State.custom;
+        customStateHint = e.toLocalizedMessage(context);
+      });
     } on GeneralResponse catch (response) {
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);

--- a/lib/pages/study/midterm_alerts_page.dart
+++ b/lib/pages/study/midterm_alerts_page.dart
@@ -247,22 +247,15 @@ class _MidtermAlertsPageState extends State<MidtermAlertsPage> {
         _getMidtermAlertsData();
       }
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        UiUtil.instance.showToast(context, response.getGeneralMessage(context));
-      }
-    } on DioException catch (e) {
-      if (e.i18nMessage != null && mounted) {
-        UiUtil.instance.showToast(context, e.i18nMessage!);
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getSemester',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }
@@ -294,6 +287,7 @@ class _MidtermAlertsPageState extends State<MidtermAlertsPage> {
         });
       }
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);
       }
@@ -301,27 +295,11 @@ class _MidtermAlertsPageState extends State<MidtermAlertsPage> {
         state = _State.custom;
         customStateHint = e.toLocalizedMessage(context);
       });
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      setState(() {
-        state = _State.custom;
-        customStateHint = response.getGeneralMessage(context);
-      });
-    } on DioException catch (e) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      setState(() {
-        state = _State.custom;
-        customStateHint = e.i18nMessage;
-      });
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getMidtermAlert',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }

--- a/lib/pages/study/reward_and_penalty_page.dart
+++ b/lib/pages/study/reward_and_penalty_page.dart
@@ -254,22 +254,15 @@ class _RewardAndPenaltyPageState extends State<RewardAndPenaltyPage> {
         _getRewardAndPenaltyData();
       }
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        UiUtil.instance.showToast(context, response.getGeneralMessage(context));
-      }
-    } on DioException catch (e) {
-      if (e.i18nMessage != null && mounted) {
-        UiUtil.instance.showToast(context, e.i18nMessage!);
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getSemester',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }
@@ -302,6 +295,7 @@ class _RewardAndPenaltyPageState extends State<RewardAndPenaltyPage> {
         });
       }
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);
       }
@@ -309,27 +303,11 @@ class _RewardAndPenaltyPageState extends State<RewardAndPenaltyPage> {
         state = _State.custom;
         customStateHint = e.toLocalizedMessage(context);
       });
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      setState(() {
-        state = _State.custom;
-        customStateHint = response.getGeneralMessage(context);
-      });
-    } on DioException catch (e) {
-      if (mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-      }
-      setState(() {
-        state = _State.custom;
-        customStateHint = e.i18nMessage;
-      });
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getRewardAndPenalty',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }

--- a/lib/pages/study/reward_and_penalty_page.dart
+++ b/lib/pages/study/reward_and_penalty_page.dart
@@ -1,5 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/models/reward_and_penalty_data.dart';
 import 'package:nkust_ap/utils/global.dart';
 
@@ -251,6 +253,10 @@ class _RewardAndPenaltyPageState extends State<RewardAndPenaltyPage> {
         });
         _getRewardAndPenaltyData();
       }
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       if (mounted) {
         UiUtil.instance.showToast(context, response.getGeneralMessage(context));
@@ -295,6 +301,14 @@ class _RewardAndPenaltyPageState extends State<RewardAndPenaltyPage> {
           }
         });
       }
+    } on ApException catch (e) {
+      if (mounted) {
+        _pickerController.markSemesterHasData(selectSemester!);
+      }
+      setState(() {
+        state = _State.custom;
+        customStateHint = e.toLocalizedMessage(context);
+      });
     } on GeneralResponse catch (response) {
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);

--- a/lib/pages/study/room_course_page.dart
+++ b/lib/pages/study/room_course_page.dart
@@ -1,5 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/config/constants.dart';
 import 'package:nkust_ap/models/room_data.dart';
@@ -92,19 +94,16 @@ class _EmptyRoomPageState extends State<EmptyRoomPage> {
         });
         _getRoomCourseTable();
       }
-    } on GeneralResponse catch (response) {
+    } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
-        UiUtil.instance.showToast(context, response.getGeneralMessage(context));
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on DioException catch (e) {
-      if (e.i18nMessage != null && mounted) {
-        UiUtil.instance.showToast(context, e.i18nMessage!);
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getSemester',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }
@@ -128,27 +127,20 @@ class _EmptyRoomPageState extends State<EmptyRoomPage> {
           }
         });
       }
-    } on GeneralResponse catch (generalResponse) {
+    } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         _pickerController.markSemesterHasData(selectSemester!);
         setState(() {
           state = CourseState.custom;
-          customStateHint = generalResponse.getGeneralMessage(context);
+          customStateHint = e.toLocalizedMessage(context);
         });
       }
-    } on DioException catch (e) {
-      if (e.type != DioExceptionType.cancel && mounted) {
-        _pickerController.markSemesterHasData(selectSemester!);
-        setState(() {
-          state = CourseState.custom;
-          customStateHint = e.i18nMessage;
-        });
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getRoomCourseTables',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }

--- a/lib/pages/study/room_list_page.dart
+++ b/lib/pages/study/room_list_page.dart
@@ -532,27 +532,16 @@ class RoomListPageState extends State<RoomListPage> {
         state = _State.finish;
       });
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       setState(() {
         state = _State.custom;
         customStateHint = e.toLocalizedMessage(context);
       });
-    } on GeneralResponse catch (generalResponse) {
-      setState(() {
-        state = _State.custom;
-        customStateHint = generalResponse.getGeneralMessage(context);
-      });
-    } on DioException catch (e) {
-      if (e.type != DioExceptionType.cancel) {
-        setState(() {
-          state = _State.custom;
-          customStateHint = e.i18nMessage;
-        });
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getRoomCourseTables',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }

--- a/lib/pages/study/room_list_page.dart
+++ b/lib/pages/study/room_list_page.dart
@@ -1,5 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/models/room_data.dart';
 import 'package:nkust_ap/pages/study/room_course_page.dart';
@@ -528,6 +530,11 @@ class RoomListPageState extends State<RoomListPage> {
       setState(() {
         roomData = data;
         state = _State.finish;
+      });
+    } on ApException catch (e) {
+      setState(() {
+        state = _State.custom;
+        customStateHint = e.toLocalizedMessage(context);
       });
     } on GeneralResponse catch (generalResponse) {
       setState(() {

--- a/lib/pages/study/score_page.dart
+++ b/lib/pages/study/score_page.dart
@@ -154,21 +154,6 @@ class ScorePageState extends State<ScorePage> {
           );
         }
         rethrow;
-      } catch (e) {
-        if (mounted) {
-          _pickerController.markSemesterHasData(selectSemester!);
-        }
-        if (await _loadOfflineScoreData()) {
-          if (mounted) {
-            setState(() {
-              state = ScoreState.custom;
-              customStateHint = e.toString();
-            });
-          }
-        } else if (mounted) {
-          setState(() => state = ScoreState.error);
-        }
-        rethrow;
       }
     }
   }

--- a/lib/pages/study/score_page.dart
+++ b/lib/pages/study/score_page.dart
@@ -98,22 +98,15 @@ class ScorePageState extends State<ScorePage> {
         _getSemesterScore();
       }
     } on ApException catch (e) {
+      if (e is CancelledException) return;
       if (mounted) {
         UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
       }
-    } on GeneralResponse catch (response) {
-      if (mounted) {
-        UiUtil.instance.showToast(context, response.getGeneralMessage(context));
-      }
-    } on DioException catch (e) {
-      if (e.i18nMessage != null && mounted) {
-        UiUtil.instance.showToast(context, e.i18nMessage!);
-      }
-      if (e.hasResponse) {
+      if (e is ServerException && e.httpStatusCode != null) {
         AnalyticsUtil.instance.logApiEvent(
           'getSemester',
-          e.response!.statusCode!,
-          message: e.message ?? '',
+          e.httpStatusCode!,
+          message: e.message,
         );
       }
     }
@@ -147,42 +140,20 @@ class ScorePageState extends State<ScorePage> {
         if (mounted) {
           _pickerController.markSemesterHasData(selectSemester!);
         }
-        if (await _loadOfflineScoreData()) {
+        if (await _loadOfflineScoreData() && e is! CancelledException) {
           setState(() {
             state = ScoreState.custom;
             customStateHint = e.toLocalizedMessage(context);
           });
         }
-        rethrow;
-      } on GeneralResponse catch (generalResponse) {
-        if (mounted) {
-          _pickerController.markSemesterHasData(selectSemester!);
-        }
-        if (await _loadOfflineScoreData()) {
-          setState(() {
-            state = ScoreState.custom;
-            customStateHint = generalResponse.getGeneralMessage(context);
-          });
-        }
-        rethrow;
-      } on DioException catch (e) {
-        if (mounted) {
-          _pickerController.markSemesterHasData(selectSemester!);
-        }
-        if (await _loadOfflineScoreData() &&
-            e.type != DioExceptionType.cancel) {
-          setState(() {
-            state = ScoreState.custom;
-            customStateHint = e.i18nMessage;
-          });
-        }
-        if (e.hasResponse) {
+        if (e is ServerException && e.httpStatusCode != null) {
           AnalyticsUtil.instance.logApiEvent(
             'getSemesterScore',
-            e.response!.statusCode!,
-            message: e.message ?? '',
+            e.httpStatusCode!,
+            message: e.message,
           );
         }
+        rethrow;
       } catch (e) {
         if (mounted) {
           _pickerController.markSemesterHasData(selectSemester!);

--- a/lib/pages/study/score_page.dart
+++ b/lib/pages/study/score_page.dart
@@ -1,5 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
+import 'package:nkust_ap/api/exceptions/api_exception.dart';
+import 'package:nkust_ap/api/exceptions/api_exception_l10n.dart';
 import 'package:nkust_ap/utils/global.dart';
 
 class ScorePage extends StatefulWidget {
@@ -95,6 +97,10 @@ class ScorePageState extends State<ScorePage> {
         });
         _getSemesterScore();
       }
+    } on ApException catch (e) {
+      if (mounted) {
+        UiUtil.instance.showToast(context, e.toLocalizedMessage(context));
+      }
     } on GeneralResponse catch (response) {
       if (mounted) {
         UiUtil.instance.showToast(context, response.getGeneralMessage(context));
@@ -137,6 +143,17 @@ class ScorePageState extends State<ScorePage> {
             }
           });
         }
+      } on ApException catch (e) {
+        if (mounted) {
+          _pickerController.markSemesterHasData(selectSemester!);
+        }
+        if (await _loadOfflineScoreData()) {
+          setState(() {
+            state = ScoreState.custom;
+            customStateHint = e.toLocalizedMessage(context);
+          });
+        }
+        rethrow;
       } on GeneralResponse catch (generalResponse) {
         if (mounted) {
           _pickerController.markSemesterHasData(selectSemester!);


### PR DESCRIPTION
## 摘要

實作 #372 的全部 6 項任務，並在實作過程中進一步擴充 — UI 層現在統一只用一個 `on ApException catch` 處理所有爬蟲錯誤，所有 HTTP status code / GeneralResponse / DioException 的 magic number 和分支判斷都被類型化例外取代。

Closes #372

---

## ApException 階層（最終版）

所有 11 個子型別都是 `sealed class ApException` 的直接子類，集中於 `lib/api/exceptions/api_exception.dart`：

```
sealed ApException
├── AuthException (reason: AuthFailureReason)
│   ├── invalidCredentials   ← WebAP 密碼錯、5 次失敗
│   ├── tooManyAttempts
│   ├── wrongCampus          ← Bus 登入 code 400
│   └── unknown              ← SSO 轉跳失敗
├── NetworkException         ← 傳輸層（含 SSL / badCertificate）
├── ServerException          ← 5xx / 回應格式錯誤
├── CaptchaException         ← OCR 耗盡重試
├── CancelledException       ← WebView 取消 / 使用者中止
├── PlatformUnsupportedException ← Bus 在 Web 平台
├── ApSessionExpiredException    ← WebAP session
├── BusSessionExpiredException   ← Bus session
├── AccountNotSupportedException ← Bus 401 / Leave 403（帳號不支援）
├── CampusNotSupportedException  ← Bus 403（校區不支援）
└── UnknownException         ← 非預期錯誤兜底（TypeError 等）
```

`ApExceptionL10n.toLocalizedMessage(context)` extension 為每個子型別提供對應的本地化訊息。

---

## 核心機制

### 1. `Helper._call<T>()` 是唯一的例外轉譯邊界

```dart
Future<T> _call<T>(Future<T> Function() body) async {
  try {
    return await body();
  } on ApException catch (e, s) {
    _maybeRecordApException(e, s);   // 只記錄高訊號（Server/Captcha）
    rethrow;
  } on DioException catch (e) {
    throw e.toApException();          // 透過 extension 翻譯
  } catch (e, s) {
    CrashlyticsUtil.instance.recordError(e, s);
    throw UnknownException(message: '${e.runtimeType}: $e', cause: e, causeStackTrace: s);
  }
}
```

- **ApException → 直接 rethrow**，其中 `ServerException` / `CaptchaException` 記錄到 Crashlytics 以追蹤 regression
- **DioException → `e.toApException()`**：transport 類 → `NetworkException`；badResponse → `ServerException`；cancel → `CancelledException`
- **其他（TypeError / FormatException / 等）→ 原始錯誤記錄 Crashlytics，包成 `UnknownException`**

### 2. Bus / Leave 子系統特化包裝

HTTP 401/403 在 bus / leave 有明確業務語意，不該讓 UI 用 magic number 判斷：

```dart
Future<T> _busCall<T>(body) => _call(() async {
  try { return await body(); }
  on DioException catch (e) {
    if (e.response?.statusCode == 401) throw const AccountNotSupportedException();
    if (e.response?.statusCode == 403) throw const CampusNotSupportedException();
    rethrow;
  }
});

Future<T> _leaveCall<T>(body) => _call(() async {
  try { return await body(); }
  on DioException catch (e) {
    if (e.response?.statusCode == 403) throw const AccountNotSupportedException();
    rethrow;
  }
});
```

### 3. UI 統一契約

所有資料抓取頁面只有一個 handler：

```dart
try {
  await Helper.instance.getXxx(...);
} on ApException catch (e) {
  if (e is CancelledException) return;
  if (e is AccountNotSupportedException) { state = userNotSupport; return; }
  if (e is CampusNotSupportedException)  { state = campusNotSupport; return; }
  showToast(e.toLocalizedMessage(context));
}
```

`grep "on GeneralResponse\|on DioException" lib/pages/` → 零結果

`grep "httpStatusCode == 401\|httpStatusCode == 403" lib/pages/` → 零結果

---

## 修復的既有 Bug

1. **網路斷線登入顯示「驗證碼錯誤」**：`_doLogin` 的通用 catch 吞掉 transport error 並進 captcha retry 迴圈，5 次耗盡後丟 `CaptchaException` 顯示「驗證碼錯誤」。改為任何 `DioException`（含 cancel / transport / badResponse）都立即短路。
2. **`_getUserInfo` 失敗永久空白**：耗盡 relogin 重試後放棄，之後其他請求成功 relogin 也無法通知首頁重抓（延續 #370 的 `onReloginSuccess` broadcast）。
3. **多處 `throw 'NullThrownError'` 字串字面量**：改為 `StateError('Helper.username/password not configured')`。
4. **`getBusTimeTables` 的 `canReserve == false` 誤用 `httpStatusCode: 403`**：業務規則被誤譯為「校區不支援」，改為不帶 status code，UI 依 `e.message.isNotEmpty` 呈現學校提供的原因。
5. **`LeaveHelper.isCookieAlive` 吞所有例外**：SSL / timeout 被誤判為 session 過期。改為 transport 類（含 `badCertificate`）拋 `NetworkException`。
6. **Bus 登入誤用回傳值通訊**：`busLogin()` 回 `Map?` 要呼叫端自行檢查 `.code == 302 / 400`，改為拋 `AuthException` 與 WebAP contract 一致。

---

## 變更範圍

**18 個 commits，28 個檔案改動，+1056 / -789 行**

- `lib/api/exceptions/` — 新增 2 個檔案（階層 + l10n extension）
- `lib/api/` — 7 個檔案遷移（ap_helper、bus_helper、leave_helper、mobile_nkust_helper、nkust_helper、helper、relogin_mixin）
- `lib/pages/` — 14 個頁面移除 `on GeneralResponse` / `on DioException` / magic number 判斷，統一 `on ApException`

---

## Crashlytics 覆蓋

| 情境 | 是否入 Crashlytics |
|------|------------------|
| 非預期例外（TypeError / FormatException / plugin 錯誤）| ✅ 原始 cause 連 stack 一起記錄 |
| `ServerException`（5xx 或非預期 response）| ✅ 用於追蹤學校系統 regression |
| `CaptchaException`（5 次都失敗）| ✅ 用於追蹤 OCR regression |
| Captcha 個別失敗（retry 迴圈內）| ✅ 每次皆記錄 |
| Parser 解析失敗 | ✅ 各 parser 自行 `recordError` |
| 使用者行為（密碼錯、網路斷、取消、session 過期）| ❌ 避免 dashboard 被雜訊淹沒 |

---

## 測試計畫

- [x] `flutter analyze lib/`：0 errors
- [x] `flutter test test/model_test.dart`：3/3 通過
- [x] 手動：密碼錯顯示「帳號或密碼錯誤或是此帳號無法使用」+ 自動登入關閉
- [ ] 手動：網路斷線登入顯示「沒有網路連線」（不再是驗證碼錯誤）
- [ ] 手動：captcha 連 5 次失敗顯示「驗證碼錯誤」
- [ ] 手動：非學生登入 Bus 顯示「使用者無法使用此功能」
- [ ] 手動：Web 平台開 Bus 顯示「此平台無法使用此功能」
- [ ] 手動：WebAP session 過期 relogin 成功，UI 正常
- [ ] 手動：使用者取消 Leave WebView 無錯誤訊息
- [ ] Crashlytics 只看到 Server / Captcha / Unknown 三類非致命錯誤

---

## 相關與後續

- 延續自 #342（relogin workflow）、#370（single-flight relogin）
- #375 追蹤移除舊 API Server 遺留 dead code（7 個未使用方法）