### PR TITLE
chore(api): 移除舊 API Server 遺留 dead code (#374)

### DIFF
--- a/lib/api/ap_status_code.dart
+++ b/lib/api/ap_status_code.dart
@@ -9,7 +9,5 @@ class ApStatusCode {
   static const int passwordFiveTimesError = 1405;
 
   //Common
-  static const int apiExpire = 401;
-  static const int apiServerError = 500;
   static const int schoolServerError = 503;
 }

--- a/lib/api/helper.dart
+++ b/lib/api/helper.dart
@@ -622,28 +622,6 @@ extension NewsExtension on Announcement {
 
 extension DioErrorExtension on DioException {
   bool get hasResponse => type == DioExceptionType.badResponse;
-
-  bool get isExpire => response!.statusCode == ApStatusCode.apiExpire;
-
-  bool get isServerError =>
-      response!.statusCode == ApStatusCode.schoolServerError ||
-      response!.statusCode == ApStatusCode.apiServerError;
-
-  GeneralResponse get serverErrorResponse {
-    switch (response!.statusCode) {
-      case ApStatusCode.apiServerError:
-        return GeneralResponse(
-          statusCode: ApStatusCode.apiServerError,
-          message: 'api server error',
-        );
-      case ApStatusCode.schoolServerError:
-      default:
-        return GeneralResponse(
-          statusCode: ApStatusCode.schoolServerError,
-          message: 'shool server error',
-        );
-    }
-  }
 }
 
 extension GeneralResponseExtension on GeneralResponse {
@@ -654,10 +632,6 @@ extension GeneralResponseExtension on GeneralResponse {
     switch (statusCode) {
       case ApStatusCode.schoolServerError:
         message = ap.schoolServerError;
-      case ApStatusCode.apiServerError:
-        message = ap.schoolServerError;
-      case ApStatusCode.apiExpire:
-        message = ap.tokenExpiredContent;
       case GeneralResponse.platformNotSupportCode:
         message = ap.platformError;
       default:

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -812,8 +812,6 @@ class HomePageState extends State<HomePage> {
         switch (response.statusCode) {
           case ApStatusCode.schoolServerError:
             message = ap.schoolServerError;
-          case ApStatusCode.apiServerError:
-            message = ap.apiServerError;
           case ApStatusCode.unknownError:
           case ApStatusCode.cancel:
             message = ap.loginFail;

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -212,8 +212,6 @@ class LoginPageState extends State<LoginPage> {
         switch (response.statusCode) {
           case ApStatusCode.schoolServerError:
             message = ap.schoolServerError;
-          case ApStatusCode.apiServerError:
-            message = ap.apiServerError;
           case ApStatusCode.userDataError:
             message = ap.loginFail;
           case ApStatusCode.passwordFiveTimesError:


### PR DESCRIPTION
### **User description**
## 摘要

App 已完全爬蟲化一段時間，但 middle-tier API Server 時代留下的程式碼還有幾個 dead 元件未清理。此 PR 把它們移除。

Closes #374

## 變更內容

### `lib/api/helper.dart`
移除三個 `DioErrorExtension` 成員（grep 確認 codebase 無任何外部呼叫點）：
- `isExpire` — 檢查 HTTP 401，對應舊 API Server JWT 過期
- `isServerError` — 檢查 503 或 500
- `serverErrorResponse` — 產生 \`GeneralResponse\` 物件，依 500 / 503 回傳不同訊息

`GeneralResponseExtension.getGeneralMessage` 的 `apiExpire` 和 `apiServerError` case 一併清除——爬蟲不會產生帶這些 code 的 `GeneralResponse`。

### `lib/api/ap_status_code.dart`
移除兩個常數：
- `apiExpire = 401`
- `apiServerError = 500`

HTTP 401 / 500 是學校系統可能回傳的真實 status code，但已經由 `DioException` 層級處理，不需要這兩個「來自校務通 API Server」的內部語意標記。

### `lib/pages/login_page.dart` / `lib/pages/home_page.dart`
移除 `_login()` 的 \`case ApStatusCode.apiServerError\` 分支。

**行為變化（極輕微）：** 若 \`GeneralResponse.statusCode == 500\` 走到 UI，訊息會從 \`ap.apiServerError\`（「校務通伺服器錯誤」）改為 default 分支的 \`ap.somethingError\`（「發生錯誤」）。但這個情境在 crawler-only 架構下理論上不會發生——WebApHelper 將學校回的 500 對映成 \`schoolServerError (503)\`，BusHelper 不回這種 code。

## 測試計畫

- [x] \`flutter analyze lib/\`：0 errors
- [x] \`flutter test test/model_test.dart\`：3/3 通過
- [x] \`grep \"apiExpire\\|apiServerError\\|isExpire\\|isServerError\\|serverErrorResponse\" lib/\` → 只剩 unrelated 同名符號（\`Helper.isExpire()\` 方法檢查 \`expireTime\`、\`SessionState.isExpired\`）
- [ ] 手動：正常登入、登出、切換學期等流程無 regression

## 相關

- 延續自 #372 的錯誤處理盤點
- 與 #373（ApException 階層）**獨立**；兩個 PR 無檔案層級衝突以外的相依，可任意順序合併


___

### **PR Type**
Enhancement


___

### **Description**
- 移除舊 API Server 相關程式碼。

- 刪除無用 `DioErrorExtension` 方法。

- 廢除 `ApStatusCode` 舊常數。

- 清理 UI 頁面中錯誤處理邏輯。


___

