### PR TITLE
refactor(parser): 抽出共用的 clearTransEncoding 函式

### DIFF
--- a/lib/api/parser/ap_parser.dart
+++ b/lib/api/parser/ap_parser.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:developer';
 import 'dart:io';
 
@@ -8,6 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:nkust_ap/api/helper.dart';
+import 'package:nkust_ap/api/parser/parser_utils.dart';
 
 //TODO confirm this rule
 //ignore_for_file: unreachable_from_main
@@ -20,42 +20,6 @@ class WebApParser {
   // ignore: prefer_constructors_over_static_methods
   static WebApParser get instance {
     return _instance ??= WebApParser();
-  }
-
-  String clearTransEncoding(List<int> htmlBytes) {
-    // htmlBytes is fixed-length list, need copy.
-    final List<int> tempData = List<int>.from(htmlBytes);
-
-    //Add /r/n on first word.
-    tempData.insert(0, 10);
-    tempData.insert(0, 13);
-
-    int startIndex = 0;
-    for (int i = 0; i < tempData.length - 1; i++) {
-      //check i and i+1 is /r/n
-      if (tempData[i] == 13 && tempData[i + 1] == 10) {
-        if (i - startIndex - 2 <= 4 && i - startIndex - 2 > 0) {
-          //check in this range word is number or A~F (Hex)
-          int removeCount = 0;
-          for (int strIndex = startIndex + 2; strIndex < i; strIndex++) {
-            if ((tempData[strIndex] > 47 && tempData[strIndex] < 58) ||
-                (tempData[strIndex] > 64 && tempData[strIndex] < 71) ||
-                (tempData[strIndex] > 96 && tempData[strIndex] < 103)) {
-              removeCount++;
-            }
-          }
-          if (removeCount == i - startIndex - 2) {
-            tempData.removeRange(startIndex, i + 2);
-          }
-          //Subtract offset
-          i -= i - startIndex - 2;
-          startIndex -= i - startIndex - 2;
-        }
-        startIndex = i;
-      }
-    }
-
-    return utf8.decode(tempData, allowMalformed: true);
   }
 
   int apLoginParser(dynamic html) {

--- a/lib/api/parser/parser_utils.dart
+++ b/lib/api/parser/parser_utils.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+/// Strips HTTP chunked-transfer-encoding hex length markers that leak into
+/// the response body, then UTF-8 decodes the result.
+///
+/// WebAP and Stdsys occasionally return bodies where the chunk size lines
+/// (e.g. `\r\n1F4\r\n`) are still embedded in the payload instead of being
+/// consumed by the transport layer. Strip any `\r\n<hex>\r\n` segment whose
+/// hex run is 1–4 characters long before decoding.
+String clearTransEncoding(List<int> htmlBytes) {
+  // htmlBytes is fixed-length list, need copy.
+  final List<int> tempData = List<int>.from(htmlBytes);
+
+  //Add /r/n on first word.
+  tempData.insert(0, 10);
+  tempData.insert(0, 13);
+
+  int startIndex = 0;
+  for (int i = 0; i < tempData.length - 1; i++) {
+    //check i and i+1 is /r/n
+    if (tempData[i] == 13 && tempData[i + 1] == 10) {
+      if (i - startIndex - 2 <= 4 && i - startIndex - 2 > 0) {
+        //check in this range word is number or A~F (Hex)
+        int removeCount = 0;
+        for (int strIndex = startIndex + 2; strIndex < i; strIndex++) {
+          if ((tempData[strIndex] > 47 && tempData[strIndex] < 58) ||
+              (tempData[strIndex] > 64 && tempData[strIndex] < 71) ||
+              (tempData[strIndex] > 96 && tempData[strIndex] < 103)) {
+            removeCount++;
+          }
+        }
+        if (removeCount == i - startIndex - 2) {
+          tempData.removeRange(startIndex, i + 2);
+        }
+        //Subtract offset
+        i -= i - startIndex - 2;
+        startIndex -= i - startIndex - 2;
+      }
+      startIndex = i;
+    }
+  }
+
+  return utf8.decode(tempData, allowMalformed: true);
+}

--- a/lib/api/parser/stdsys_parser.dart
+++ b/lib/api/parser/stdsys_parser.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:ap_common/ap_common.dart';
+import 'package:nkust_ap/api/parser/parser_utils.dart';
 
 class StdsysParser {
   static StdsysParser? _instance;
@@ -11,42 +12,6 @@ class StdsysParser {
   // ignore: prefer_constructors_over_static_methods
   static StdsysParser get instance {
     return _instance ??= StdsysParser();
-  }
-
-  String clearTransEncoding(List<int> htmlBytes) {
-    // htmlBytes is fixed-length list, need copy.
-    final List<int> tempData = List<int>.from(htmlBytes);
-
-    //Add /r/n on first word.
-    tempData.insert(0, 10);
-    tempData.insert(0, 13);
-
-    int startIndex = 0;
-    for (int i = 0; i < tempData.length - 1; i++) {
-      //check i and i+1 is /r/n
-      if (tempData[i] == 13 && tempData[i + 1] == 10) {
-        if (i - startIndex - 2 <= 4 && i - startIndex - 2 > 0) {
-          //check in this range word is number or A~F (Hex)
-          int removeCount = 0;
-          for (int strIndex = startIndex + 2; strIndex < i; strIndex++) {
-            if ((tempData[strIndex] > 47 && tempData[strIndex] < 58) ||
-                (tempData[strIndex] > 64 && tempData[strIndex] < 71) ||
-                (tempData[strIndex] > 96 && tempData[strIndex] < 103)) {
-              removeCount++;
-            }
-          }
-          if (removeCount == i - startIndex - 2) {
-            tempData.removeRange(startIndex, i + 2);
-          }
-          //Subtract offset
-          i -= i - startIndex - 2;
-          startIndex -= i - startIndex - 2;
-        }
-        startIndex = i;
-      }
-    }
-
-    return utf8.decode(tempData, allowMalformed: true);
   }
 
   Map<String, dynamic> roomListParser(String? jsonString) {


### PR DESCRIPTION
### **User description**
## 摘要

- `WebApParser` 與 `StdsysParser` 各自帶著一份 byte-for-byte 相同的 `clearTransEncoding`（35 行 × 2），用來剝除 WebAP/Stdsys 回應裡殘留的 HTTP chunked transfer-encoding hex 長度標記（`\r\n<hex>\r\n`）後再 UTF-8 decode。
- 把此函式提為 `lib/api/parser/parser_utils.dart` 的頂層函式，兩個 parser 改為 import 使用，順手移除 `ap_parser.dart` 裡已無人用的 `dart:convert` import。
- 淨效果：+46 / −73（淨 −27 行）。行為零變動。

## 動機

對應 #230 checklist 的「抽取共用工具方法（如 `clearTransEncoding()`）」項目。這是爬蟲類別重構裡唯一真正 byte-for-byte 重複的工具函式（用 `diff` 驗證過兩份輸出為空）。其餘 parser 彼此差異較大，暫不強行抽象。

## Test plan

- [x] `flutter analyze lib/api/parser/` — 0 errors / 0 warnings（分支上只剩既有的 info-level lint）
- [x] `flutter test test/api_parser_test.dart` — 42/42 通過
- [ ] CI 綠燈

## 關聯

- #230（爬蟲類別重構）


___

### **PR Type**
Enhancement


___

### **Description**
- 提取重複的 `clearTransEncoding` 函式。

- 將函式移至 `parser_utils.dart`。

- 改善程式碼複用性與可維護性。

- 移除 `ap_parser.dart` 中不必要的引用。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["lib/api/parser/ap_parser.dart"] --> C["lib/api/parser/parser_utils.dart"]
  B["lib/api/parser/stdsys_parser.dart"] --> C
  subgraph 移除重複程式碼
    A -- "移除 clearTransEncoding" --> A_new
    B -- "移除 clearTransEncoding" --> B_new
  end
  subgraph 提取共用函式
    C_new["lib/api/parser/parser_utils.dart"] -- "新增 clearTransEncoding" --> C
  end
```

