### PR TITLE
chore: 升級 Flutter 至 3.41.7

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.38.10",
+  "flutter": "3.41.7",
   "flavors": {}
 }

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 env:
-  flutter_version: '3.38.x'
+  flutter_version: '3.41.x'
   java_version: '21'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 env:
-  flutter_version: '3.38.x'
+  flutter_version: '3.41.x'
   java_version: '21'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/crawler-monitor.yml
+++ b/.github/workflows/crawler-monitor.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  flutter_version: '3.38.x'
+  flutter_version: '3.41.x'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
-flutter = "3.38.10"
+flutter = "3.41.7"
 java = "zulu-21"
 ruby = "3.3"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -253,10 +253,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1121,18 +1121,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1662,10 +1662,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:
@@ -1851,5 +1851,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.35.1"


### PR DESCRIPTION
### **User description**
## 摘要

把專案的 Flutter SDK 從 **3.38.10** 升級到 **3.41.7**（系列最新 stable patch）。

## 變更檔案

| 檔案 | 變更 |
|---|---|
| `.fvmrc` | `"flutter": "3.38.10"` → `"3.41.7"` |
| `mise.toml` | `flutter = "3.38.10"` → `"3.41.7"` |
| `.github/workflows/ci.yml` | `flutter_version: '3.38.x'` → `'3.41.x'` |
| `.github/workflows/cd.yml` | 同上 |
| `.github/workflows/crawler-monitor.yml` | 同上 |
| `pubspec.lock` | Dart 3.11 自動選版：`characters` 1.4.0 → 1.4.1、`matcher` 0.12.17 → 0.12.19、`material_color_utilities` 0.11.1 → 0.13.0、`test_api` 0.7.7 → 0.7.10 |

## 為什麼不動 `pubspec.yaml`

`environment.sdk: '>=3.6.0 <4.0.0'` 已涵蓋 Dart 3.9（3.38 搭載）與 Dart 3.11（3.41 搭載），不需調整。lockfile 底部的 `sdks.dart` 僅由 transitive 套件反推出，會自動隨升級遞進。

## 驗證

- `fvm flutter analyze`：**零新 error / warning**。既有的 unused_import 清單（`ap_helper.dart`、`bus_helper.dart`、`leave_helper.dart` 等的 `dio/io.dart`、`native_dio_adapter` 等）與 3.38.10 完全一致，屬於 #309 的範疇。
- `fvm flutter test test/api_parser_test.dart`：**34 / 34 通過**。
- `fvm flutter test`（全套）：37 passed, 1 skipped, 1 failed。唯一失敗是 `test/widget_test.dart` 的 smoke test（`FirebaseException: No Firebase App '[DEFAULT]' has been created`）— 此為 master 上長期既有的問題，非本 PR 造成。

## 相依套件相容度檢查

於 3.41.7 本機執行 `pub get` 順利解決，無任何主要套件需要 major bump。高風險套件均能直跑：

- `tflite_flutter`
- `flutter_inappwebview`
- `syncfusion_flutter_pdf`
- `dio` / `native_dio_adapter`

## Test plan

- [x] 本機 analyze 綠
- [x] 本機 parser 測試綠
- [x] 本機全測試（扣除既有 smoke test）綠
- [ ] CI 綠燈
- [ ] 實機 smoke test（登入 / 課表 / 成績 / 校車 / 缺曠）— 合併前人工驗過

Closes #381


___

### **PR Type**
Enhancement


___

### **Description**
- 將 Flutter SDK 升級至 3.41.7

- 更新 FVM 與 mise 工具配置

- 更新 GitHub Actions 工作流程的 Flutter 版本


___

