### PR TITLE
fix(ci): macOS 部署自動匯入 Installer Distribution 憑證

### DIFF
--- a/.github/scripts/aggregate_changelog.sh
+++ b/.github/scripts/aggregate_changelog.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# aggregate_changelog.sh <beta|stable> <output_file>
+#
+# Queries GitHub API for merged PRs since last release and aggregates
+# bilingual changelog entries from PR comments.
+#
+# Output format: JSON array of {"zh-TW": "...", "en-US": "..."}
+
+set -euo pipefail
+
+RELEASE_TYPE="${1:-beta}"
+OUTPUT_FILE="${2:-changelog_aggregated.json}"
+
+# Find last release tag by type
+if [ "$RELEASE_TYPE" = "stable" ]; then
+  LAST_TAG=$(gh release list --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // ""')
+else
+  LAST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+fi
+
+if [ -n "$LAST_TAG" ]; then
+  LAST_DATE=$(gh release view "$LAST_TAG" --json publishedAt --jq '.publishedAt')
+  echo "Aggregating changelog since: $LAST_TAG ($LAST_DATE)"
+else
+  LAST_DATE="1970-01-01T00:00:00Z"
+  echo "No previous release found, aggregating all entries"
+fi
+
+# Get merged PRs to develop since last release (newest first)
+PRS=$(gh pr list \
+  --base develop \
+  --state merged \
+  --limit 100 \
+  --json number,mergedAt \
+  --jq "[.[] | select(.mergedAt > \"$LAST_DATE\") | .number]")
+
+PR_COUNT=$(echo "$PRS" | jq length)
+echo "Found $PR_COUNT merged PR(s)"
+
+ENTRIES="[]"
+
+for PR_NUM in $(echo "$PRS" | jq -r '.[]'); do
+  # Find the last changelog-entry comment on this PR
+  COMMENT=$(gh api "repos/$GITHUB_REPOSITORY/issues/${PR_NUM}/comments" \
+    --jq '[.[] | select(.body | startswith("<!-- changelog-entry")) | .body] | last // ""')
+
+  if [ -z "$COMMENT" ] || [ "$COMMENT" = "null" ]; then
+    echo "PR #$PR_NUM: no changelog comment, skipping"
+    continue
+  fi
+
+  # Extract JSON from between the comment markers (expects single-line JSON)
+  ENTRY=$(echo "$COMMENT" | awk '/<!-- changelog-entry/{found=1;next}/-->/{found=0}found' | head -1 | xargs)
+
+  if echo "$ENTRY" | jq -e '.["zh-TW"] and .["en-US"]' > /dev/null 2>&1; then
+    ENTRIES=$(echo "$ENTRIES" | jq ". + [$ENTRY]")
+    echo "PR #$PR_NUM: added — $(echo "$ENTRY" | jq -r '.["en-US"]')"
+  else
+    echo "PR #$PR_NUM: malformed changelog JSON, skipping"
+  fi
+done
+
+echo "$ENTRIES" > "$OUTPUT_FILE"
+echo "Aggregated $(echo "$ENTRIES" | jq length) entries → $OUTPUT_FILE"

--- a/.github/scripts/generate_changelog.sh
+++ b/.github/scripts/generate_changelog.sh
@@ -5,9 +5,78 @@ VERSION_CODE="$1"
 TARGET="$2" # android, ios, macos, or github
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ---------------------------------------------------------------------------
+# New path: use LLM-aggregated changelog if AGGREGATED_CHANGELOG is set
+# ---------------------------------------------------------------------------
+if [ -n "${AGGREGATED_CHANGELOG:-}" ] && [ -f "$AGGREGATED_CHANGELOG" ]; then
+  ENTRY_COUNT=$(jq length "$AGGREGATED_CHANGELOG")
+
+  if [ "$ENTRY_COUNT" -eq 0 ]; then
+    echo "WARNING: No aggregated changelog entries found for ${TARGET}, using fallback."
+    FALLBACK="Bug fixes and improvements."
+    case "$TARGET" in
+      android)
+        for locale in "en-US" "zh-TW"; do
+          mkdir -p "metadata/android/${locale}/changelogs/"
+          echo "$FALLBACK" > "metadata/android/${locale}/changelogs/default.txt"
+        done
+        ;;
+      ios|macos)
+        echo "$FALLBACK" > "en-US.txt"
+        echo "問題修正與效能改善。" > "zh-TW.txt"
+        ;;
+      github)
+        echo "Bug fixes and improvements." > RELEASE_NOTES_GENERATED.md
+        ;;
+    esac
+    exit 0
+  fi
+
+  case "$TARGET" in
+    android)
+      for locale in "en-US" "zh-TW"; do
+        mkdir -p "metadata/android/${locale}/changelogs/"
+        jq -r ".[] | \"* \" + .[\"${locale}\"]" "$AGGREGATED_CHANGELOG" \
+          > "metadata/android/${locale}/changelogs/default.txt"
+      done
+      echo "Generated Android changelog ($ENTRY_COUNT entries)"
+      ;;
+    ios|macos)
+      for locale in "en-US" "zh-TW"; do
+        jq -r ".[] | \"* \" + .[\"${locale}\"]" "$AGGREGATED_CHANGELOG" \
+          > "${locale}.txt"
+      done
+      echo "Generated ${TARGET} changelog ($ENTRY_COUNT entries)"
+      ;;
+    github)
+      VERSION="${RELEASE_VERSION:-unknown}"
+      {
+        echo "## v${VERSION}"
+        echo ""
+        echo "**What's New**"
+        jq -r ".[] | \"- \" + .[\"en-US\"]" "$AGGREGATED_CHANGELOG"
+        echo ""
+        echo "---"
+        echo ""
+        echo "**更新內容**"
+        jq -r ".[] | \"- \" + .[\"zh-TW\"]" "$AGGREGATED_CHANGELOG"
+      } > RELEASE_NOTES_GENERATED.md
+      echo "Generated GitHub release notes ($ENTRY_COUNT entries)"
+      ;;
+    *)
+      echo "ERROR: Unknown target '${TARGET}'. Use: android, ios, macos, or github"
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Legacy path: read from changelog.json keyed by version_code
+# ---------------------------------------------------------------------------
 CHANGELOG_FILE="$SCRIPT_DIR/../../changelog.json"
 
-# Validate version code exists in changelog.json
 if ! jq -e ".\"${VERSION_CODE}\"" "$CHANGELOG_FILE" > /dev/null 2>&1; then
   echo "WARNING: Version code ${VERSION_CODE} not found in ${CHANGELOG_FILE}, skipping changelog generation."
   exit 0

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,7 +126,6 @@ jobs:
     name: macOS Deploy TestFlight
     needs: prepare
     runs-on: self-hosted
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -141,6 +140,21 @@ jobs:
       - name: Flutter Initialize
         run: flutter doctor -v
       - run: flutter pub get
+      - name: Import Mac Installer Distribution certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MAC_INSTALLER_CERT_BASE64 }}
+          p12-password: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
+          keychain: mac-installer-signing
+          keychain-password: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
+      - name: Verify Installer Distribution identity is available
+        run: |
+          if ! security find-identity -v | grep -q "3rd Party Mac Developer Installer"; then
+            echo "::error::3rd Party Mac Developer Installer identity not found in any keychain after import. Verify MAC_INSTALLER_CERT_BASE64 / MAC_INSTALLER_CERT_PASSWORD secrets contain a valid Installer Distribution .p12."
+            security find-identity -v || true
+            exit 1
+          fi
+          security find-identity -v | grep "3rd Party Mac Developer Installer"
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} macos
         working-directory: ./macos/fastlane

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,6 +5,18 @@ on:
     branches:
       - production
       - develop
+    paths:
+      - 'lib/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+      - '.github/workflows/cd.yml'
+      - '.github/scripts/**'
   workflow_dispatch:
 
 env:
@@ -15,6 +27,7 @@ env:
 permissions:
   contents: write
   actions: write
+  pull-requests: read
 
 jobs:
   prepare:
@@ -36,6 +49,17 @@ jobs:
         run: |
           echo "version_code=${{ vars.VERSION_CODE }}" >> $GITHUB_OUTPUT
           echo "Using version code: ${{ vars.VERSION_CODE }}"
+      - name: Aggregate changelog from merged PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TYPE=${{ github.ref == 'refs/heads/production' && 'stable' || 'beta' }}
+          bash "$GITHUB_WORKSPACE/.github/scripts/aggregate_changelog.sh" "$RELEASE_TYPE" changelog_aggregated.json
+      - name: Upload aggregated changelog
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-aggregated
+          path: changelog_aggregated.json
 
   deploy_android:
     name: Android Play Store
@@ -53,9 +77,15 @@ jobs:
         run: sh ./.github/scripts/decrypt_android_keys.sh
         env:
           KEYS_SECRET_PASSPHRASE: ${{ secrets.KEYS_SECRET_PASSPHRASE }}
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} android
         working-directory: ./android/fastlane
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -91,9 +121,15 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ env.java_version }}
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} ios
         working-directory: ./ios/fastlane
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -141,9 +177,15 @@ jobs:
       - name: Flutter Initialize
         run: flutter doctor -v
       - run: flutter pub get
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} macos
         working-directory: ./macos/fastlane
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Build macOS
         run: flutter build macos --release --build-number=${{ needs.prepare.outputs.version_code }}
       - name: Decode API Key
@@ -252,8 +294,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Download aggregated changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: changelog-aggregated
       - name: Generate release notes
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} github
+        env:
+          AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
       - name: Download Windows installer
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,34 @@ on:
     branches:
       - master
       - develop
+    paths:
+      - 'lib/**'
+      - 'test/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches:
       - master
       - develop
+    paths:
+      - 'lib/**'
+      - 'test/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+      - '.github/workflows/ci.yml'
 
 env:
   flutter_version: '3.38.x'

--- a/.github/workflows/pr_changelog.yml
+++ b/.github/workflows/pr_changelog.yml
@@ -66,7 +66,6 @@ jobs:
             exit 0
           }
 
-          gh pr comment "$PR_NUMBER" --body "<!-- changelog-entry
-${ENTRY}
--->"
+          COMMENT_BODY=$(printf '<!-- changelog-entry\n%s\n-->' "$ENTRY")
+          gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
           echo "Posted changelog entry for PR #$PR_NUMBER"

--- a/.github/workflows/pr_changelog.yml
+++ b/.github/workflows/pr_changelog.yml
@@ -1,0 +1,72 @@
+name: PR Changelog Generator
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+    paths:
+      - 'lib/**'
+      - 'pubspec.yaml'
+      - 'pubspec.lock'
+      - 'android/**'
+      - 'ios/**'
+      - 'macos/**'
+      - 'linux/**'
+      - 'windows/**'
+      - 'assets/**'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  generate:
+    name: Generate Changelog Entry
+    if: github.event.pull_request.merged == true
+    runs-on: self-hosted
+    steps:
+      - name: Generate bilingual changelog entry via Ollama
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          PR_BODY="${{ github.event.pull_request.body }}"
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          REQUEST=$(jq -n \
+            --arg title "$PR_TITLE" \
+            --arg body "$PR_BODY" \
+            '{
+              model: "qwen2.5:3b",
+              messages: [
+                {
+                  role: "system",
+                  content: "你是 App 更新說明撰寫員。根據 PR 資訊，用一句話生成使用者可看懂的更新描述。繁體中文使用台灣用語，避免技術術語。只輸出 JSON，格式為 {\"zh-TW\": \"...\", \"en-US\": \"...\"}，不要其他文字。"
+                },
+                {
+                  role: "user",
+                  content: ("PR Title: " + $title + "\nPR Description: " + $body)
+                }
+              ],
+              temperature: 0.3
+            }')
+
+          RESPONSE=$(curl -sf http://localhost:11434/v1/chat/completions \
+            -H "Content-Type: application/json" \
+            -d "$REQUEST") || {
+            echo "::warning::Ollama request failed, skipping changelog generation"
+            exit 0
+          }
+
+          ENTRY=$(echo "$RESPONSE" | jq -r '.choices[0].message.content' | tr -d '\n')
+
+          # Validate JSON has required fields
+          echo "$ENTRY" | jq -e '.["zh-TW"] and .["en-US"]' > /dev/null 2>&1 || {
+            echo "::warning::LLM returned invalid JSON: $ENTRY"
+            exit 0
+          }
+
+          gh pr comment "$PR_NUMBER" --body "<!-- changelog-entry
+${ENTRY}
+-->"
+          echo "Posted changelog entry for PR #$PR_NUMBER"


### PR DESCRIPTION
## 摘要

修掉 `deploy_macos` job 長期靜默失敗的根因 — self-hosted runner 的 keychain 裡沒有 Mac Installer Distribution 憑證，導致 Fastfile 的 `productbuild --sign` 拋 `Could not find appropriate signing identity`。失敗被 `continue-on-error: true` 吞掉，`finalize` 仍照樣往下跑、`VERSION_CODE` 還是會遞增，於是 macOS 其實從未成功上 TestFlight 卻沒人注意到。

## 變更

1. **拔掉 `continue-on-error: true`** — 讓 `deploy_macos` 失敗時整個 workflow 亮紅，避免假 success
2. **新增 `apple-actions/import-codesign-certs@v3` 步驟** — 從新 secret `MAC_INSTALLER_CERT_BASE64` + `MAC_INSTALLER_CERT_PASSWORD` 把 Installer .p12 匯入獨立的 `mac-installer-signing` keychain，不再依賴 runner 預先安裝憑證
3. **Pre-flight `security find-identity` 檢查** — 匯入後若找不到 `3rd Party Mac Developer Installer` 身分就以清楚的 `::error::` 訊息 fail，不讓 productbuild 的 cryptic stack trace 埋沒問題

## 需要先在 repo 設定的 secrets

Merge 這個 PR 前，**請先在 GitHub repo Settings → Secrets and variables → Actions 新增**：

| Secret | 內容 |
|---|---|
| `MAC_INSTALLER_CERT_BASE64` | Installer Distribution `.p12` 的 base64（`base64 -i cert.p12`） |
| `MAC_INSTALLER_CERT_PASSWORD` | 該 .p12 的匯出密碼 |

舊 secret `MAC_INSALLER_DISTRIBUTION_CERT_NAME`（拼字沿用既有）保留、不需改。

## Diff

```
 .github/workflows/cd.yml | 16 +++++++++++++++-
 1 file changed, 15 insertions(+), 1 deletion(-)
```

## Test plan

- [ ] 設定兩個新 secret
- [ ] 觀察下一次 `cd.yml` 跑完後 `deploy_macos` job 綠燈 + TestFlight 收到新 build
- [ ] 若憑證有問題，pre-flight 會在 Fastlane 之前就清楚報錯

## 備註

- `import-codesign-certs@v3` 會自動把 `mac-installer-signing` keychain 加進 search list，並在 job 結束時 cleanup
- 同一顆 runner 上既有的 iOS Application Distribution 憑證不受影響（不同 keychain、不同 cert type）
- Fastfile 完全不需動，`productbuild --sign` 會透過 search list 自動找到新 keychain 裡的憑證

Refs #312