### PR TITLE
fix(ci): macOS 部署前用 App Distribution 憑證簽章並嵌入 entitlements

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -183,14 +183,30 @@ jobs:
           p12-password: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
           keychain: mac-installer-signing
           keychain-password: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
-      - name: Verify Installer Distribution identity is available
+      - name: Import Mac App Distribution certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MAC_APP_CERT_BASE64 }}
+          p12-password: ${{ secrets.MAC_APP_CERT_PASSWORD }}
+          keychain: mac-app-signing
+          keychain-password: ${{ secrets.MAC_APP_CERT_PASSWORD }}
+          create-keychain: true
+      - name: Verify Mac signing identities are available
         run: |
+          missing=0
           if ! security find-identity -v | grep -q "3rd Party Mac Developer Installer"; then
-            echo "::error::3rd Party Mac Developer Installer identity not found in any keychain after import. Verify MAC_INSTALLER_CERT_BASE64 / MAC_INSTALLER_CERT_PASSWORD secrets contain a valid Installer Distribution .p12."
+            echo "::error::3rd Party Mac Developer Installer identity missing. Check MAC_INSTALLER_CERT_BASE64 / MAC_INSTALLER_CERT_PASSWORD."
+            missing=1
+          fi
+          if ! security find-identity -v | grep -q "3rd Party Mac Developer Application"; then
+            echo "::error::3rd Party Mac Developer Application identity missing. Check MAC_APP_CERT_BASE64 / MAC_APP_CERT_PASSWORD."
+            missing=1
+          fi
+          if [ "$missing" = "1" ]; then
             security find-identity -v || true
             exit 1
           fi
-          security find-identity -v | grep "3rd Party Mac Developer Installer"
+          security find-identity -v | grep "3rd Party Mac Developer"
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} macos
         working-directory: ./macos/fastlane
@@ -198,6 +214,26 @@ jobs:
           AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Build macOS
         run: flutter build macos --release --build-number=${{ needs.prepare.outputs.version_code }}
+      - name: Codesign macOS .app with Release entitlements
+        env:
+          MAC_APP_DISTRIBUTION_CERT_NAME: ${{ secrets.MAC_APP_DISTRIBUTION_CERT_NAME }}
+        run: |
+          APP_PATH="$(find build/macos/Build/Products/Release -maxdepth 1 -type d -name '*.app' | head -n1)"
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::No .app bundle found under build/macos/Build/Products/Release"
+            exit 1
+          fi
+          echo "Signing $APP_PATH"
+          codesign --force --deep --options runtime --timestamp \
+            --entitlements macos/Runner/Release.entitlements \
+            --sign "$MAC_APP_DISTRIBUTION_CERT_NAME" \
+            "$APP_PATH"
+          codesign --verify --verbose=2 "$APP_PATH"
+          codesign --display --entitlements :- "$APP_PATH" | \
+            grep -q "com.apple.security.app-sandbox" || {
+              echo "::error::app-sandbox entitlement missing from signed .app"
+              exit 1
+            }
       - name: Decode API Key
         run: |
           echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode > macos/AuthKey.p8


### PR DESCRIPTION
### **User description**
## 摘要

#384 修好 \`productbuild\` 的 Installer 簽章，暴露出下一層問題：App Store Connect 拒收 pkg，`altool` 回 `Validation failed (409) App sandbox not enabled`。

根因：\`flutter build macos --release\` 產出的 \`.app\` 是**未簽章**的，entitlement 只有在 codesign 時才會嵌進 Mach-O 執行檔。原本流程直接 \`productbuild --sign <installer>\` 包 pkg，installer 簽章只蓋在 pkg 外層，.app 內部仍沒有 \`com.apple.security.app-sandbox\` entitlement，App Store Connect 因此拒收。

`macos/Runner/Release.entitlements` 檔案本身正確（`app-sandbox=true`），只是沒有被套用。

## 變更

1. **再匯入一顆憑證**：`3rd Party Mac Developer Application`，來源用新 secret `MAC_APP_CERT_BASE64` / `MAC_APP_CERT_PASSWORD`，放進獨立 keychain `mac-app-signing`
2. **Pre-flight 一併驗兩顆身分**：Installer + Application 缺一就 fail
3. **Build 後新增 codesign 步驟**：
   - 找到 \`build/macos/Build/Products/Release/*.app\`
   - \`codesign --force --deep --options runtime --timestamp --entitlements macos/Runner/Release.entitlements --sign "$MAC_APP_DISTRIBUTION_CERT_NAME"\`
   - 驗證 \`codesign --verify\` 通過
   - 驗證 \`codesign --display --entitlements :-\` 裡確實有 \`app-sandbox\` 字串，沒有就 fail
4. 之後 Fastlane 的 \`productbuild --sign <installer>\` 照舊跑，因為 .app 已經簽好，installer 簽章只要包外層

## 需要先在 repo 設定的 secrets

Merge 前請新增：

| Secret | 內容 |
|---|---|
| `MAC_APP_CERT_BASE64` | 3rd Party Mac Developer Application `.p12` 的 base64 |
| `MAC_APP_CERT_PASSWORD` | 該 .p12 的匯出密碼 |
| `MAC_APP_DISTRIBUTION_CERT_NAME` | 憑證的 common name，例：`3rd Party Mac Developer Application: Open Culture Foundation (5SP52F6F2C)` |

base64 產生指令：

```bash
base64 -i mac_app_distribution.p12 | pbcopy
```

## Diff

```
 .github/workflows/cd.yml | 42 +++++++++++++++++++++++++++++++++++++++---
 1 file changed, 39 insertions(+), 3 deletions(-)
```

## Test plan

- [ ] 新增 3 個 secret
- [ ] 觀察下一次 `cd.yml` 跑的 `deploy_macos` job：
  - Codesign 步驟的 `codesign --verify` 過關
  - entitlements 檢查印出 `com.apple.security.app-sandbox`
  - Fastlane 的 `upload_to_testflight` 不再拋 409 validation error
  - TestFlight 頁面收到新 macOS build

## 關聯

- 上一手 #384（Installer 憑證匯入）
- Refs #312


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 解決 macOS App Store Connect 拒收問題。

- 導入第二個憑證用於 App 簽章。

- 在部署前對 `.app` 進行沙盒簽章。

- 統一驗證 macOS 簽章身份。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build macOS"] --> B["Codesign macOS .app with Entitlements"]
  B --> C["Deploy macOS to TestFlight"]
```

