### PR TITLE
fix(ci): self-hosted runner 的 macOS 簽章 keychain 做 idempotent 清理

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -176,6 +176,15 @@ jobs:
       - name: Flutter Initialize
         run: flutter doctor -v
       - run: flutter pub get
+      - name: Clean previous signing keychains (self-hosted idempotency)
+        # Self-hosted runners keep ~/Library/Keychains between jobs, so
+        # apple-actions/import-codesign-certs fails on the second run
+        # with exit 48 ("A keychain with the same name already exists").
+        # Remove any leftover keychains from earlier runs so the import
+        # steps below can always create a fresh one.
+        run: |
+          security delete-keychain mac-installer-signing.keychain 2>/dev/null || true
+          security delete-keychain mac-app-signing.keychain 2>/dev/null || true
       - name: Import Mac Installer Distribution certificate
         uses: apple-actions/import-codesign-certs@v3
         with:


### PR DESCRIPTION
### **User description**
## 摘要

#384 / #386 在 GitHub-hosted runner 上會正常跑，但在 self-hosted runner（本專案實際使用的部署方式）跑第二次以後一定死在第一個匯入步驟：

```
security: SecKeychainCreate mac-installer-signing.keychain:
A keychain with the same name already exists.
##[error]The process '/usr/bin/security' failed with exit code 48
```

根因：self-hosted runner 的 \`~/Library/Keychains/\` **在 jobs 之間不會被清掉**。\`apple-actions/import-codesign-certs@v3\` 內部呼叫 \`security create-keychain\` 時不處理「已存在」的情況，直接 exit 48。

GitHub-hosted runner 每次從乾淨 VM 開始所以不會撞到。

## 變更

在 \`Import Mac Installer Distribution certificate\` 前加一步：

```yaml
- name: Clean previous signing keychains (self-hosted idempotency)
  run: |
    security delete-keychain mac-installer-signing.keychain 2>/dev/null || true
    security delete-keychain mac-app-signing.keychain 2>/dev/null || true
```

- 不存在時 `|| true` 吞掉退出碼
- stderr 導到 `/dev/null` 避免 log 噪音
- 後續兩個匯入步驟照舊，每次都從乾淨狀態重建

## 觀察到的 side-effect

`apple-actions/import-codesign-certs@v3` action 自帶的 post-step 清理，在 self-hosted runner 上顯然沒真的清掉 keychain 檔（#384 合掉跑完那次留下的檔就是證據）。與其依賴 action 的 post-step，不如在 job 開頭主動 pre-clean 來得可靠。

## Test plan

- [ ] 觀察下一次 CD 的 `deploy_macos` job：
  - `Clean previous signing keychains` 步驟跑成功
  - 兩個 `Import Mac ... certificate` 步驟不再撞 exit 48
  - Pre-flight 身分驗證通過
  - Codesign + productbuild + upload_to_testflight 整串綠燈

Refs #312


___

### **PR Type**
Bug fix


___

### **Description**
- 解決自託管 runner 憑證匯入失敗問題。

- 在憑證匯入前清理舊的簽章鑰匙圈。

- 確保 macOS 部署 CI/CD 流程的冪等性。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["deploy_macos Job"] --> B{"Clean previous signing keychains"}
  B --> C["Import Mac Installer Distribution certificate"]
  C --> D["Import Mac App Distribution certificate"]
```

