### PR TITLE
fix(ci): macOS 簽章 pre-flight 區分「憑證不存在」與「缺私鑰」

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -202,16 +202,35 @@ jobs:
           create-keychain: true
       - name: Verify Mac signing identities are available
         run: |
+          # A valid "identity" means cert + matching private key are both
+          # present in the keychain. If the .p12 was exported without its
+          # private key (i.e. selecting only the certificate row in
+          # Keychain Access instead of Cmd-clicking both the cert AND
+          # the private key child, so "Export 2 items" appears),
+          # `security import` still succeeds and the cert shows up under
+          # `find-certificate`, but `find-identity` won't list it —
+          # signing fails later with a confusing error. Detect both
+          # failure modes separately so the fix (re-export the .p12
+          # correctly vs. upload the right .p12 in the first place) is
+          # obvious.
+          check_identity() {
+            local label="$1" cn_prefix="$2" base_secret="$3" pwd_secret="$4"
+            if security find-identity -v | grep -q "$cn_prefix"; then
+              echo "  ✓ $label identity present"
+              return 0
+            fi
+            if security find-certificate -c "$cn_prefix" >/dev/null 2>&1; then
+              echo "::error::$label certificate is imported but has no matching private key. The .p12 in $base_secret was exported without the private key. Re-export from Keychain Access with BOTH the cert row AND its private key child selected ('Export 2 items…')."
+            else
+              echo "::error::$label certificate not found in any keychain. Verify $base_secret contains a valid .p12 and $pwd_secret matches its export password."
+            fi
+            return 1
+          }
           missing=0
-          if ! security find-identity -v | grep -q "3rd Party Mac Developer Installer"; then
-            echo "::error::3rd Party Mac Developer Installer identity missing. Check MAC_INSTALLER_CERT_BASE64 / MAC_INSTALLER_CERT_PASSWORD."
-            missing=1
-          fi
-          if ! security find-identity -v | grep -q "3rd Party Mac Developer Application"; then
-            echo "::error::3rd Party Mac Developer Application identity missing. Check MAC_APP_CERT_BASE64 / MAC_APP_CERT_PASSWORD."
-            missing=1
-          fi
+          check_identity "Installer"    "3rd Party Mac Developer Installer"    MAC_INSTALLER_CERT_BASE64 MAC_INSTALLER_CERT_PASSWORD || missing=1
+          check_identity "Application"  "3rd Party Mac Developer Application"  MAC_APP_CERT_BASE64       MAC_APP_CERT_PASSWORD       || missing=1
           if [ "$missing" = "1" ]; then
+            echo "--- current signing identities ---"
             security find-identity -v || true
             exit 1
           fi


### PR DESCRIPTION
## 摘要

上次 CD 跑的 \`deploy_macos\` job 停在 pre-flight：

```
::error::3rd Party Mac Developer Application identity missing.
Check MAC_APP_CERT_BASE64 / MAC_APP_CERT_PASSWORD.
```

但同一段 log 的 \`security import\` 沒有任何錯誤，\`security find-certificate\` 能找到 App Distribution 憑證。真正的原因是 **.p12 匯出時沒帶私鑰**：

- Keychain Access 若只點到憑證那一列就 Export，產出的 \`.p12\` 只有公鑰
- \`security import\` 照樣成功（合法 PKCS#12 可以純 cert）
- 但 \`security find-identity -v\` 不列它（identity = cert + 匹配私鑰）
- 後面的 \`codesign\` / \`productbuild\` 一旦去用就會以模糊的錯誤訊息死

正確的匯出要 Cmd-click 同時選起「憑證 + 私鑰子項」，右鍵顯示 **Export 2 items…** 才對。

原本的驗證訊息把兩種完全不同的失敗（根本沒匯進去 vs 匯進去但缺私鑰）合成同一句「missing / 檢查 secret」，誤導排查方向。

## 變更

把 verify 改寫成一個 \`check_identity\` helper：

1. 先 \`security find-identity -v | grep <prefix>\` — 命中就 OK
2. 沒命中，改 \`security find-certificate -c <prefix>\` — 命中代表**憑證在、私鑰不在**，印出「re-export with Export 2 items」提示
3. 都沒命中才是真的「憑證沒匯進去」— 印出「檢查 base64 secret 與密碼」提示

兩種失敗給不同的 remediation 訊息，下次誰踩到都能看一眼知道要改哪邊。

## 不改的

- 不改 action 版本、不改 import 流程
- 不改 secret 清單
- 不動 codesign / productbuild 步驟

## Test plan

- [ ] 觀察下一次 CD 的 \`deploy_macos\` pre-flight：
  - 若 `MAC_APP_CERT_BASE64` 還沒更新成含私鑰的 .p12 → 應該看到 "certificate is imported but has no matching private key" 的明確訊息
  - 若已更新 → 兩個 identity 都 OK、繼續跑 codesign / productbuild
- 這個 PR 本身不會讓 CD 自己變綠；它只是讓失敗訊息更有用

Refs #312