### PR TITLE
fix(course): 切換舊學期時避免覆蓋桌面小工具資料

### DIFF
--- a/lib/pages/study/course_page.dart
+++ b/lib/pages/study/course_page.dart
@@ -187,7 +187,8 @@ class CoursePageState extends State<CoursePage> {
             _pickerController.markSemesterHasData(selectSemester!);
           }
         });
-        if (courseData.courses.isNotEmpty) {
+        if (courseData.courses.isNotEmpty &&
+            selectSemester!.code == semesterData!.defaultSemester.code) {
           await ApCommonPlugin.updateCourseWidget(courseData);
         }
       }


### PR DESCRIPTION
### **User description**
## Summary

- `course_page.dart` 在 `_getCourseTables()` 載入成功後會呼叫 `ApCommonPlugin.updateCourseWidget(courseData)`，但沒判斷載入的是否為預設（最新）學期，造成使用者切到舊學期時把桌面小工具資料覆蓋成舊的。
- 參考 ap_common PR [#179](https://github.com/abc873693/ap_common/pull/179) 修正該議題的方向，在 App 端加上 `selectSemester.code == semesterData.defaultSemester.code` 判斷，與同檔案 `enableNotifyControl` 使用的條件一致。

## Test plan

- [ ] 登入後載入預設學期，確認桌面小工具正確更新
- [ ] 切到舊學期，確認桌面小工具不會被舊學期資料覆蓋
- [ ] `flutter analyze lib/pages/study/course_page.dart` 通過（本地已驗證）


___

### **PR Type**
Bug fix


___

### **Description**
- 避免舊學期資料覆蓋桌面小工具。

- 僅在載入預設學期時更新小工具。


___

