### PR TITLE
chore(deps): 升級 ap_common 至 dev.12/dev.13

### DIFF
--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,11 +14,11 @@ import firebase_messaging
 import firebase_remote_config
 import flutter_inappwebview_macos
 import flutter_local_notifications
+import gal
 import google_sign_in_ios
 import in_app_review
 import package_info_plus
 import path_provider_foundation
-import photo_manager
 import printing
 import share_plus
 import shared_preferences_foundation
@@ -36,11 +36,11 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FirebaseRemoteConfigPlugin.register(with: registry.registrar(forPlugin: "FirebaseRemoteConfigPlugin"))
   InAppWebViewFlutterPlugin.register(with: registry.registrar(forPlugin: "InAppWebViewFlutterPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
+  GalPlugin.register(with: registry.registrar(forPlugin: "GalPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   InAppReviewPlugin.register(with: registry.registrar(forPlugin: "InAppReviewPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  PhotoManagerPlugin.register(with: registry.registrar(forPlugin: "PhotoManagerPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.15'
+platform :osx, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -121,6 +121,9 @@ PODS:
   - flutter_local_notifications (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
+  - gal (1.0.0):
+    - Flutter
+    - FlutterMacOS
   - google_sign_in_ios (0.0.1):
     - AppAuth (>= 1.7.4)
     - Flutter
@@ -206,9 +209,6 @@ PODS:
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - photo_manager (3.7.1):
-    - Flutter
-    - FlutterMacOS
   - printing (1.0.0):
     - FlutterMacOS
   - PromisesObjC (2.4.0)
@@ -239,12 +239,12 @@ DEPENDENCIES:
   - flutter_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos`)
   - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
+  - gal (from `Flutter/ephemeral/.symlinks/plugins/gal/darwin`)
   - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
   - in_app_review (from `Flutter/ephemeral/.symlinks/plugins/in_app_review/macos`)
   - objective_c (from `Flutter/ephemeral/.symlinks/plugins/objective_c/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
   - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
-  - photo_manager (from `Flutter/ephemeral/.symlinks/plugins/photo_manager/macos`)
   - printing (from `Flutter/ephemeral/.symlinks/plugins/printing/macos`)
   - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
@@ -302,6 +302,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
+  gal:
+    :path: Flutter/ephemeral/.symlinks/plugins/gal/darwin
   google_sign_in_ios:
     :path: Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin
   in_app_review:
@@ -312,8 +314,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
   path_provider_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
-  photo_manager:
-    :path: Flutter/ephemeral/.symlinks/plugins/photo_manager/macos
   printing:
     :path: Flutter/ephemeral/.symlinks/plugins/printing/macos
   share_plus:
@@ -352,7 +352,8 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 9d2fa84a46676302b89dbd5e6e62bce2fe376909
   flutter_inappwebview_macos: c2d68649f9f8f1831bfcd98d73fd6256366d9d1d
   flutter_local_notifications: 7e5a17a1dbc00d83dc10d43c2c4c05f2ceed233c
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  gal: baecd024ebfd13c441269ca7404792a7152fde89
   google_sign_in_ios: 0ab078e60da6dfe23cbc55c83502b52bba1aad63
   GoogleAppMeasurement: fce7c1c90640d2f9f5c56771f71deacb2ba3f98c
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
@@ -366,7 +367,6 @@ SPEC CHECKSUMS:
   OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
   package_info_plus: f0052d280d17aa382b932f399edf32507174e870
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  photo_manager: 1d80ae07a89a67dfbcae95953a1e5a24af7c3e62
   printing: c4cf83c78fd684f9bc318e6aadc18972aa48f617
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
@@ -376,6 +376,6 @@ SPEC CHECKSUMS:
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
 
-PODFILE CHECKSUM: 0d3963a09fc94f580682bd88480486da345dc3f0
+PODFILE CHECKSUM: 8d40c19d3cbdb380d870685c3a564c989f1efa52
 
 COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -359,12 +359,12 @@
 				"${BUILT_PRODUCTS_DIR}/file_selector_macos/file_selector_macos.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_inappwebview_macos/flutter_inappwebview_macos.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_local_notifications/flutter_local_notifications.framework",
+				"${BUILT_PRODUCTS_DIR}/gal/gal.framework",
 				"${BUILT_PRODUCTS_DIR}/in_app_review/in_app_review.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 				"${BUILT_PRODUCTS_DIR}/objective_c/objective_c.framework",
 				"${BUILT_PRODUCTS_DIR}/package_info_plus/package_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
-				"${BUILT_PRODUCTS_DIR}/photo_manager/photo_manager.framework",
 				"${BUILT_PRODUCTS_DIR}/printing/printing.framework",
 				"${BUILT_PRODUCTS_DIR}/share_plus/share_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/shared_preferences_foundation/shared_preferences_foundation.framework",
@@ -399,12 +399,12 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/file_selector_macos.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_inappwebview_macos.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_local_notifications.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/gal.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/in_app_review.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/objective_c.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/photo_manager.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/printing.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_foundation.framework",
@@ -540,7 +540,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -627,7 +627,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -675,7 +675,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,66 +37,66 @@ packages:
     dependency: "direct main"
     description:
       name: ap_common
-      sha256: ea33c62c8e36d748b0481e2903baf45e17d84dd60ceabe313d05ab4a6fe8ad0b
+      sha256: "5e6cf9d29275969495741ec3d9acc058467bed632f532ccd249f441692fecf1d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-dev.11"
+    version: "1.0.1-dev.12"
   ap_common_announcement_ui:
     dependency: transitive
     description:
       name: ap_common_announcement_ui
-      sha256: dcceb1501e6a258ad9ba99f6f00e1fadf60a1f90256210d4e97f89de3cc736a5
+      sha256: "22dd6fd1b5ee9544e86bf1bdcda6bcc6324b9abf4c86839fe839835f8f9a7469"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-dev.12"
+    version: "1.0.1-dev.13"
   ap_common_core:
     dependency: transitive
     description:
       name: ap_common_core
-      sha256: "80eaeae5cf689dcc84bc99f50af57e672c709fe7514f8b88c3cec99c88c04f97"
+      sha256: "3ddea8040e454cc5be04fbeaa1660fa68afb88f0ac4317122f5c0a585a5d6540"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-dev.9"
+    version: "1.0.1-dev.10"
   ap_common_firebase:
     dependency: "direct main"
     description:
       name: ap_common_firebase
-      sha256: "515a4ec129c4298e09bd0c33c2c2d60c20dd678997aebafb8c0bcdc268962046"
+      sha256: bfb6adf3556e1beb0d680007fac4ee72c5e52e1a36239550f98eda322cec5b67
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-dev.12"
+    version: "1.0.1-dev.13"
   ap_common_flutter_core:
     dependency: transitive
     description:
       name: ap_common_flutter_core
-      sha256: a962ed39ff1e81cb08b8c415c38ed6c46c9a886e38da627dbed1f509f57f5fd7
+      sha256: "3f6d6fe2c6cb6c17ed5cfeefab50f9f596030f08cc0e0a3925674f869f5d5295"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0-dev.12"
+    version: "1.1.0-dev.13"
   ap_common_flutter_platform:
     dependency: transitive
     description:
       name: ap_common_flutter_platform
-      sha256: bfccf273cacd3d41f56fac74c93321ac618b1a8a36aabee688997e08bec1fe31
+      sha256: "7cb7b7ff27bb1039b1b0799899a793eac166a082414cdf650f9a685f3662a1a2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-dev.12"
+    version: "1.0.1-dev.13"
   ap_common_flutter_ui:
     dependency: transitive
     description:
       name: ap_common_flutter_ui
-      sha256: "2cc376a4ae8570dc805d97a19ef81a568ef098802948bfd7280f245f90f2a951"
+      sha256: "69b210a1e2250ab72356dcd89c1b1a9abcd567f3d931a0785794225a3cf6a26f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0-dev.12"
+    version: "1.1.0-dev.13"
   ap_common_plugin:
     dependency: "direct main"
     description:
       name: ap_common_plugin
-      sha256: "2df41046a958837f53bb06ff88120772c89258ed8b3b0ce7e844f617076a1c4d"
+      sha256: "5ad4e44fa833ddc7411cea55b2bd806c0b78bf643870e3d03b0953a06cdf4bf7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-dev.11"
+    version: "1.0.1-dev.12"
   app_tracking_transparency:
     dependency: transitive
     description:
@@ -797,6 +797,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  gal:
+    dependency: transitive
+    description:
+      name: gal
+      sha256: "969598f986789127fd407a750413249e1352116d4c2be66e81837ffeeaafdfee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   glob:
     dependency: transitive
     description:
@@ -1285,14 +1293,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  photo_manager:
-    dependency: transitive
-    description:
-      name: photo_manager
-      sha256: a0d9a7a9bc35eda02d33766412bde6d883a8b0acb86bbe37dac5f691a0894e8a
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.1"
   photo_view:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,9 +15,9 @@ dependencies:
     sdk: flutter
   intl: ">=0.17.0 <1.0.0"
 
-  ap_common: ^1.0.1-dev.11
-  ap_common_firebase: ^1.0.1-dev.12
-  ap_common_plugin: ^1.0.1-dev.11
+  ap_common: ^1.0.1-dev.12
+  ap_common_firebase: ^1.0.1-dev.13
+  ap_common_plugin: ^1.0.1-dev.12
   #official plugin
   http: ^0.13.3
   html: ^0.15.0

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_remote_config/firebase_remote_config_plugin_c_api.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
+#include <gal/gal_plugin_c_api.h>
 #include <printing/printing_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -26,6 +27,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseRemoteConfigPluginCApi"));
   FlutterInappwebviewWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterInappwebviewWindowsPluginCApi"));
+  GalPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GalPluginCApi"));
   PrintingPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PrintingPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_core
   firebase_remote_config
   flutter_inappwebview_windows
+  gal
   printing
   share_plus
   url_launcher_windows


### PR DESCRIPTION
### **User description**
## Summary

升級 ap_common 套件家族至 2026-04-19 發佈的新版本：

| 套件 | 前 | 後 |
|---|---|---|
| ap_common | 1.0.1-dev.11 | 1.0.1-dev.12 |
| ap_common_firebase | 1.0.1-dev.12 | 1.0.1-dev.13 |
| ap_common_plugin | 1.0.1-dev.11 | 1.0.1-dev.12 |

涵蓋自上次發版以來的 4 個 PR：

- abc873693/ap_common#166 `refactor(platform):` 以 `gal` 取代 `photo_manager` 進行圖片儲存，並新增 macOS / Windows 桌面平台支援
- abc873693/ap_common#179 `fix(course):` `onCourseLoaded` 新增 `isDefaultSemester` 參數（nkust_ap 端改善於 #389）
- abc873693/ap_common#180 `fix(ui):` `ScoreScaffold` gradePoint 模式下 GPA 等第、標準差、學分統計顯示修正
- abc873693/ap_common#186 `feat(ui):` 新增可切換課表配色系統 `CoursePaletteTheme`（非 breaking，未注入時視覺不變）

## Changes

- `pubspec.yaml` / `pubspec.lock` 版本 bump
- `macos/Flutter/GeneratedPluginRegistrant.swift` — `photo_manager` 移除、`gal` 加入
- `windows/flutter/generated_plugin_registrant.cc` / `generated_plugins.cmake` — 新增 `gal` 註冊（Windows 首次支援匯出課表圖片）

## Test plan

- [x] `flutter pub get` 無衝突，`photo_manager` 自動被移除
- [x] `flutter analyze` 無新增 error（既有 warnings/infos 不變）
- [ ] Android 實機：匯出課表圖片可正常寫入相簿（改走 `gal`）
- [ ] iOS 實機：匯出課表圖片可正常寫入相簿
- [ ] macOS 桌面：plugin registrant 包含 `gal`，不影響啟動
- [ ] 成績頁（gradePoint 模式若有）顯示正常
- [ ] 課表頁基本操作（載入、切學期、下拉刷新、桌面小工具同步）無回歸


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- 升級 `ap_common` 系列套件至 `dev.12`/`dev.13` 版本。

- 替換 `photo_manager` 為 `gal` 以支援圖片儲存，並新增 Windows/macOS 平台支援。

- 修正切換舊學期時桌面小工具資料被覆蓋的問題。

- 包含 `ScoreScaffold` 顯示修正及新增課表配色系統。


___

