### PR TITLE
fix(ci+macos): deployment target + keychain search list for macOS deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -200,29 +200,45 @@ jobs:
           keychain: mac-app-signing
           keychain-password: ${{ secrets.MAC_APP_CERT_PASSWORD }}
           create-keychain: true
+      - name: Consolidate keychain search list
+        # apple-actions/import-codesign-certs@v3 calls
+        # `security list-keychains -d user -s <new>.keychain login.keychain`
+        # after each import, which REPLACES the search list. The second
+        # import therefore evicts mac-installer-signing from the search
+        # list, and downstream `security find-identity` / `find-certificate`
+        # / `codesign` / `productbuild` cannot see the Installer identity
+        # at all. Force both custom keychains plus login back into the
+        # search list so subsequent steps see the full inventory.
+        run: |
+          security list-keychains -d user -s \
+            mac-installer-signing.keychain \
+            mac-app-signing.keychain \
+            login.keychain
+          echo "User-domain search list after consolidation:"
+          security list-keychains -d user
       - name: Verify Mac signing identities are available
         run: |
           # A valid "identity" means cert + matching private key are both
-          # present in the keychain. If the .p12 was exported without its
-          # private key (i.e. selecting only the certificate row in
-          # Keychain Access instead of Cmd-clicking both the cert AND
-          # the private key child, so "Export 2 items" appears),
-          # `security import` still succeeds and the cert shows up under
-          # `find-certificate`, but `find-identity` won't list it —
-          # signing fails later with a confusing error. Detect both
-          # failure modes separately so the fix (re-export the .p12
-          # correctly vs. upload the right .p12 in the first place) is
-          # obvious.
+          # present in the keychain. Diagnose three possible failure
+          # modes separately so the remediation is obvious:
+          #   A. identity visible   → OK
+          #   B. cert present but no matching key → .p12 exported
+          #      without selecting the private key row
+          #   C. cert absent entirely → wrong .p12 / wrong password
+          # Queries are scoped to the two custom keychains so we don't
+          # get false positives from an unrelated cert left over in
+          # the login keychain from earlier experiments.
+          KEYCHAINS=(mac-installer-signing.keychain mac-app-signing.keychain)
           check_identity() {
             local label="$1" cn_prefix="$2" base_secret="$3" pwd_secret="$4"
-            if security find-identity -v | grep -q "$cn_prefix"; then
+            if security find-identity -v "${KEYCHAINS[@]}" | grep -q "$cn_prefix"; then
               echo "  ✓ $label identity present"
               return 0
             fi
-            if security find-certificate -c "$cn_prefix" >/dev/null 2>&1; then
+            if security find-certificate -a -c "$cn_prefix" "${KEYCHAINS[@]}" 2>/dev/null | grep -q "labl"; then
               echo "::error::$label certificate is imported but has no matching private key. The .p12 in $base_secret was exported without the private key. Re-export from Keychain Access with BOTH the cert row AND its private key child selected ('Export 2 items…')."
             else
-              echo "::error::$label certificate not found in any keychain. Verify $base_secret contains a valid .p12 and $pwd_secret matches its export password."
+              echo "::error::$label certificate not found in mac-installer-signing / mac-app-signing keychains. Verify $base_secret contains a valid .p12 and $pwd_secret matches its export password."
             fi
             return 1
           }
@@ -230,11 +246,15 @@ jobs:
           check_identity "Installer"    "3rd Party Mac Developer Installer"    MAC_INSTALLER_CERT_BASE64 MAC_INSTALLER_CERT_PASSWORD || missing=1
           check_identity "Application"  "3rd Party Mac Developer Application"  MAC_APP_CERT_BASE64       MAC_APP_CERT_PASSWORD       || missing=1
           if [ "$missing" = "1" ]; then
-            echo "--- current signing identities ---"
+            echo "--- identities in mac-installer-signing ---"
+            security find-identity -v mac-installer-signing.keychain || true
+            echo "--- identities in mac-app-signing ---"
+            security find-identity -v mac-app-signing.keychain || true
+            echo "--- all identities (full search list) ---"
             security find-identity -v || true
             exit 1
           fi
-          security find-identity -v | grep "3rd Party Mac Developer"
+          security find-identity -v "${KEYCHAINS[@]}" | grep "3rd Party Mac Developer"
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} macos
         working-directory: ./macos/fastlane

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.15'
+platform :osx, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -359,12 +359,12 @@
 				"${BUILT_PRODUCTS_DIR}/file_selector_macos/file_selector_macos.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_inappwebview_macos/flutter_inappwebview_macos.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_local_notifications/flutter_local_notifications.framework",
+				"${BUILT_PRODUCTS_DIR}/gal/gal.framework",
 				"${BUILT_PRODUCTS_DIR}/in_app_review/in_app_review.framework",
 				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 				"${BUILT_PRODUCTS_DIR}/objective_c/objective_c.framework",
 				"${BUILT_PRODUCTS_DIR}/package_info_plus/package_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/path_provider_foundation/path_provider_foundation.framework",
-				"${BUILT_PRODUCTS_DIR}/photo_manager/photo_manager.framework",
 				"${BUILT_PRODUCTS_DIR}/printing/printing.framework",
 				"${BUILT_PRODUCTS_DIR}/share_plus/share_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/shared_preferences_foundation/shared_preferences_foundation.framework",
@@ -399,12 +399,12 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/file_selector_macos.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_inappwebview_macos.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_local_notifications.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/gal.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/in_app_review.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/objective_c.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/package_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider_foundation.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/photo_manager.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/printing.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/share_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/shared_preferences_foundation.framework",
@@ -540,7 +540,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -627,7 +627,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -675,7 +675,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;


### PR DESCRIPTION
### **User description**
## 摘要

一次解決兩個相互阻擋的 macOS 部署問題：

### (1) \`flutter build macos\` CocoaPods 錯誤

\`gal\` plugin 2.3.2 的 podspec 要 \`s.osx.deployment_target = '11.0'\`，專案 Podfile + Xcode project 還停在 10.15，integration 直接 fail：

```
Specs satisfying the `gal (from
`Flutter/ephemeral/.symlinks/plugins/gal/darwin`)` dependency were found,
but they required a higher minimum deployment target.
```

本機 \`fvm flutter build macos --release\` 改完 11.0 後產出 \`Runner.app\`（86.6 MB）。

### (2) Pre-flight 永遠說 Installer 憑證「不見」

就算 Installer 的 .p12 正確匯入 \`mac-installer-signing\` keychain、有私鑰，也會死在 verify。

根因是 \`apple-actions/import-codesign-certs@v3\` 每跑一次會做：

```
security list-keychains -d user -s <new>.keychain login.keychain
```

這個命令**替換**整個 user-domain 搜尋列表。兩次 import 跑完後搜尋列表只剩 \`mac-app-signing\` + \`login\`，**\`mac-installer-signing\` 被踢出搜尋範圍**。

後續 \`security find-identity\` / \`find-certificate\` / \`codesign\` / \`productbuild\` 預設都吃搜尋列表，所以 Installer 身分對整條流程等於不存在，即使檔案實際上在 keychain 裡。

## 變更

### \`macos/Podfile\` + \`macos/Runner.xcodeproj/project.pbxproj\`

- \`platform :osx, '10.15'\` → \`'11.0'\`
- \`MACOSX_DEPLOYMENT_TARGET\` 三處 \`10.15\` → \`11.0\`

macOS 11.0（Big Sur）2020 發佈，早已 5 年以上，使用者影響極小。

### \`.github/workflows/cd.yml\` — 新增步驟 \`Consolidate keychain search list\`

在兩次 import 後立刻：

```bash
security list-keychains -d user -s \
  mac-installer-signing.keychain \
  mac-app-signing.keychain \
  login.keychain
```

把兩個自訂 keychain + login 一起塞回搜尋列表，之後所有 security / codesign / productbuild 都看得到兩顆憑證。

### Verify 步驟強化

- \`find-identity\` / \`find-certificate\` 加上 **明確 keychain 參數**，只查 \`mac-installer-signing\` 和 \`mac-app-signing\` 兩個自訂 keychain。好處：不會被 \`login\` keychain 裡以前手動匯入的殘留憑證誤判成「cert 在、key 不在」。
- 失敗時多印：
  - \`mac-installer-signing\` 裡的 identity 列表
  - \`mac-app-signing\` 裡的 identity 列表
  - 整個搜尋列表的 identity

下次撞到問題一眼看出是哪個 keychain 裝錯東西。

## Test plan

- [x] 本機 \`fvm flutter build macos --release\` → \`Built build/macos/Build/Products/Release/NKUST AP.app (86.6MB)\`
- [ ] CD：
  - Consolidate 步驟印出包含兩顆自訂 keychain 的搜尋列表
  - Verify 印出 \`✓ Installer identity present\` + \`✓ Application identity present\`
  - Build → Codesign → productbuild → upload_to_testflight 整串綠燈

## 關聯

- #384 / #386 / #387 / #388（同一條 #312 macOS 部署修正鏈的前幾關）
- Refs #312


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 更新 macOS 部署目標至 11.0。

- 確保 CI 簽章鑰匙圈搜尋列表完整。

- 強化 macOS 簽章身份驗證訊息。

- 區分憑證問題類型以利排查。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Import Mac Installer Distribution certificate"] --> B["Import Mac App Distribution certificate"]
  B --> C["Consolidate keychain search list"]
  C --> D["Verify Mac signing identities are available"]
  D --> E["Codesign / Productbuild (downstream)"]
```

