### PR TITLE
fix(android): 保留 androidx.datastore 原生橋接避免 release 閃退

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -39,3 +39,12 @@
 ## AndroidX Window Extensions
 -dontwarn androidx.window.extensions.**
 -dontwarn androidx.window.sidecar.**
+
+## androidx.datastore JNI bridge
+# R8 was renaming NativeSharedCounter and its native method, so JNI lookup
+# for Java_androidx_datastore_core_NativeSharedCounter_nativeTruncateFile
+# failed at runtime and crashed Firebase's background DataStore reads.
+-keep class androidx.datastore.core.NativeSharedCounter { *; }
+-keepclasseswithmembernames class * {
+    native <methods>;
+}


### PR DESCRIPTION
### **User description**
## Summary

修正 release build 在 App 啟動一段時間後發生的 Fatal 閃退：

\`\`\`
java.lang.UnsatisfiedLinkError: No implementation found for int d0.n0.d(int)
  (tried Java_d0_n0_d and Java_d0_n0_d__I)
  at androidx.datastore.core.NativeSharedCounter.nativeTruncateFile
  ...
  at com.google.firebase.concurrent.CustomThreadFactory
\`\`\`

## 根因

1. \`androidx.datastore.core.NativeSharedCounter\` 的 \`nativeTruncateFile\` 是 JNI 方法，\`.so\` export 的符號是原始名 \`Java_androidx_datastore_core_NativeSharedCounter_nativeTruncateFile\`。
2. Flutter 3.41 + AGP 8.5 的 release build 會跑 R8，把該類改名成 \`d0.n0\`、方法改名成 \`d\`。
3. 執行時 JVM 照混淆後的類名找 \`Java_d0_n0_d\` → 原生庫沒這個 export → crash。
4. DataStore 是 Firebase（Remote Config / Installations / Analytics）的 transitive 依賴，懶初始化，所以**不是啟動就炸，是背景跑到才炸**，符合「開啟一段時間閃退」的現象。

預設的 \`proguard-android.txt\` 原本應該含 \`keepclasseswithmembernames class * { native <methods>; }\`，但新版 R8 full-mode 行為改變或此規則未生效，導致 native 方法被改名。

## Changes

\`android/app/proguard-rules.pro\`：
- \`-keep class androidx.datastore.core.NativeSharedCounter { *; }\` — 保留 Firebase 會用到的原生橋接類與其成員
- \`-keepclasseswithmembernames class * { native <methods>; }\` — 標準樣板，任何有 \`native\` 方法的類其成員名不被 R8 改名

## Test plan

- [ ] \`flutter build apk --release\` 成功
- [ ] release APK 實機安裝，待機 1–5 分鐘觸發 Firebase 的 DataStore code path，不再出現 \`UnsatisfiedLinkError\`
- [ ] Crashlytics 觀察數日，無新的 \`NativeSharedCounter\` 相關 crash


___

### **PR Type**
Bug fix


___

### **Description**
- 修正發布版本 `UnsatisfiedLinkError` 錯誤。

- 防止 R8 混淆 `androidx.datastore` 原生方法。

- 新增 ProGuard 規則保留原生橋接。

- 確保 JNI 符號正確解析。


___

