### PR TITLE
fix(login): 登入流程在行動網路抖動時重試 captcha 迴圈

### DIFF
--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -136,6 +136,12 @@ class WebApHelper
     //
     assert(retryCounts >= 0, 'retryCounts must be >= 0');
 
+    // Last transient transport error seen during this login attempt.
+    // Used when every captcha iteration fails due to mobile network
+    // blips so the caller gets a [NetworkException] (and the UI's
+    // "offline login" fallback) instead of a misleading
+    // [CaptchaException].
+    ApException? lastTransportError;
     for (int i = 0; i < retryCounts; i++) {
       try {
         final Uint8List? imageBytes = await getValidationImage();
@@ -168,7 +174,11 @@ class WebApHelper
           case 4:
             //Stay old password and relogin.
             await stayOldPwd();
-            return _doLogin(username: username, password: password);
+            return _doLogin(
+              username: username,
+              password: password,
+              retryCounts: retryCounts,
+            );
           case 0:
             isLogin = true;
             return LoginResponse(
@@ -201,12 +211,24 @@ class WebApHelper
         // endpoint.
         rethrow;
       } on DioException catch (e) {
-        // Any DioException — transport failure, server 4xx/5xx, or user
-        // cancellation — terminates the captcha retry loop. Another
-        // attempt with a fresh captcha cannot help when the HTTP layer
-        // itself failed, and retrying a cancelled request would waste
-        // work and produce misleading "captcha error" messages.
-        throw e.toApException();
+        // Distinguish transient transport blips (base station handoff,
+        // WiFi↔cellular switch) from terminal failures. The mobile case
+        // often outlasts RetryInterceptor's ~3s retry window but recovers
+        // within the next captcha iteration; the old code threw on the
+        // first DioException and surfaced "no network" after one blink.
+        final ApException translated = e.toApException();
+        final bool transient = e.type == DioExceptionType.connectionTimeout ||
+            e.type == DioExceptionType.sendTimeout ||
+            e.type == DioExceptionType.receiveTimeout ||
+            e.type == DioExceptionType.connectionError;
+        if (!transient) {
+          // cancel / badResponse / badCertificate / unknown — retrying
+          // with a fresh captcha cannot help, so propagate immediately.
+          throw translated;
+        }
+        lastTransportError = translated;
+        log('login attempt ${i + 1}/$retryCounts: transient ${e.type}');
+        await Future<void>.delayed(const Duration(seconds: 1));
       } catch (e, s) {
         // Truly unexpected errors (parser bugs, etc.) are logged and
         // allowed to trigger another captcha attempt.
@@ -214,7 +236,12 @@ class WebApHelper
         log(e.toString());
       }
     }
-    //
+    // All attempts exhausted. If any of them were transient transport
+    // failures, prefer that over a generic CaptchaException so the UI's
+    // NetworkException branch (offline-login prompt) fires correctly.
+    if (lastTransportError != null) {
+      throw lastTransportError;
+    }
     throw CaptchaException(
       attempts: retryCounts,
       message: 'captcha failed after $retryCounts attempts',


### PR DESCRIPTION
## 摘要

使用者回報：用行動網路登入偶爾會直接跳「沒有網路連線」，但其實網路馬上就恢復了。追下去發現是 \`WebApHelper._doLogin\` 的 captcha 重試迴圈處理 \`DioException\` 太粗暴，網路抖一下就整個放棄。

## 根因

\`lib/api/ap_helper.dart\` 的 \`_doLogin\` 原本長這樣：

\`\`\`dart
on DioException catch (e) {
  throw e.toApException();   // ← 任何 DioException 都整個放棄
}
\`\`\`

但 \`DioException\` 有好幾種：
- 真錯誤：\`cancel\` / \`badResponse\` / \`badCertificate\` — retry 沒用
- 暫時抖動：\`connectionError\` / \`connectionTimeout\` / \`sendTimeout\` / \`receiveTimeout\` — 下次 loop 可能就好

行動網路切換基地台常常斷 5–10 秒，RetryInterceptor 內建 3 次重試的 ~3 秒窗撐不過去，就把 DioException 丟出來。外層 captcha 迴圈本來可以當第二層緩衝，結果它直接 throw → 使用者看到「沒有網路連線」→ 進離線模式。其實再試一次就好了。

## 變更

### Bug 1：區分 transient vs terminal

\`\`\`dart
on DioException catch (e) {
  final transient = e.type == DioExceptionType.connectionTimeout ||
                    e.type == DioExceptionType.sendTimeout ||
                    e.type == DioExceptionType.receiveTimeout ||
                    e.type == DioExceptionType.connectionError;
  if (!transient) throw e.toApException();   // 真錯誤：立刻結束
  lastTransportError = e.toApException();    // 抖動：記下來、繼續下一 loop
  await Future.delayed(const Duration(seconds: 1));
}
\`\`\`

記一個 \`lastTransportError\`，迴圈跑完全部失敗的話用它而不是 \`CaptchaException\` — UI 的 \`if (e is NetworkException) _offlineLogin()\` 路徑仍然正常 fire。

### Bug 2：順手修 \`case 4\` 遞迴丟失 retryCounts

\`\`\`dart
case 4:
  await stayOldPwd();
-  return _doLogin(username: username, password: password);
+  return _doLogin(username: username, password: password, retryCounts: retryCounts);
\`\`\`

之前 \`case 4\`（密碼到期要延用舊密碼）遞迴時沒帶 retryCounts，預設又回到 5。小問題，但 parameter 就失去意義了。

## 副作用

| 情境 | 改前 | 改後 |
|---|---|---|
| 手機切基地台抽 5s | 一次就跳「沒網路」→ 離線模式 | 下次 loop 接上 → 成功登入 |
| 真的完全沒網路 | 立刻跳「沒網路」→ 離線模式 | 5 次都 fail → 最終仍丟 \`NetworkException\` → 離線模式照跑，只是多等 ~20s |
| Captcha OCR 失敗 | 繼續 loop | 繼續 loop（無變化） |
| 4xx / 5xx / cert 錯 | 立刻結束 | 立刻結束（無變化） |
| user cancel | 立刻結束 | 立刻結束（無變化） |

Trade-off：完全沒網的使用者會多等最多 20s 才進離線模式（原本 1 次就進）。為了多救一堆行動網路的使用者，這個代價可以接受。

## Test plan

- [x] \`fvm flutter analyze lib/api/ap_helper.dart\` — 0 errors / 0 new warnings
- [x] \`fvm flutter test test/api_parser_test.dart\` — 29/29 通過
- [ ] CI 綠燈
- [ ] 實機 smoke：
  - [ ] 好網路登入 → 正常
  - [ ] 手機開飛航模式登入 → 等 ~20s 後跳離線模式
  - [ ] 登入中途切飛航模式再關掉 → 後續 iteration 應該能接上

## 關聯

- 使用者回報：「使用行動網路時有時候會跳沒有網路連線」
- 相關：#342（之前的 per-call retry 問題，同一個檔案）