### PR TITLE
fix(login): 登入流程重試邏輯分層修正（合併 #398）

### DIFF
--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -136,6 +136,12 @@ class WebApHelper
     //
     assert(retryCounts >= 0, 'retryCounts must be >= 0');
 
+    // Last transient transport error seen during this login attempt.
+    // Used when every captcha iteration fails due to mobile network
+    // blips so the caller gets a [NetworkException] (and the UI's
+    // "offline login" fallback) instead of a misleading
+    // [CaptchaException].
+    ApException? lastTransportError;
     for (int i = 0; i < retryCounts; i++) {
       try {
         final Uint8List? imageBytes = await getValidationImage();
@@ -168,7 +174,11 @@ class WebApHelper
           case 4:
             //Stay old password and relogin.
             await stayOldPwd();
-            return _doLogin(username: username, password: password);
+            return _doLogin(
+              username: username,
+              password: password,
+              retryCounts: retryCounts,
+            );
           case 0:
             isLogin = true;
             return LoginResponse(
@@ -201,12 +211,24 @@ class WebApHelper
         // endpoint.
         rethrow;
       } on DioException catch (e) {
-        // Any DioException — transport failure, server 4xx/5xx, or user
-        // cancellation — terminates the captcha retry loop. Another
-        // attempt with a fresh captcha cannot help when the HTTP layer
-        // itself failed, and retrying a cancelled request would waste
-        // work and produce misleading "captcha error" messages.
-        throw e.toApException();
+        // Distinguish transient transport blips (base station handoff,
+        // WiFi↔cellular switch) from terminal failures. The mobile case
+        // often outlasts RetryInterceptor's ~3s retry window but recovers
+        // within the next captcha iteration; the old code threw on the
+        // first DioException and surfaced "no network" after one blink.
+        final ApException translated = e.toApException();
+        final bool transient = e.type == DioExceptionType.connectionTimeout ||
+            e.type == DioExceptionType.sendTimeout ||
+            e.type == DioExceptionType.receiveTimeout ||
+            e.type == DioExceptionType.connectionError;
+        if (!transient) {
+          // cancel / badResponse / badCertificate / unknown — retrying
+          // with a fresh captcha cannot help, so propagate immediately.
+          throw translated;
+        }
+        lastTransportError = translated;
+        log('login attempt ${i + 1}/$retryCounts: transient ${e.type}');
+        await Future<void>.delayed(const Duration(seconds: 1));
       } catch (e, s) {
         // Truly unexpected errors (parser bugs, etc.) are logged and
         // allowed to trigger another captcha attempt.
@@ -214,7 +236,12 @@ class WebApHelper
         log('[login] attempt ${i + 1}/$retryCounts: $e');
       }
     }
-    //
+    // All attempts exhausted. If any of them were transient transport
+    // failures, prefer that over a generic CaptchaException so the UI's
+    // NetworkException branch (offline-login prompt) fires correctly.
+    if (lastTransportError != null) {
+      throw lastTransportError;
+    }
     throw CaptchaException(
       attempts: retryCounts,
       message: 'captcha failed after $retryCounts attempts',

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -498,14 +498,36 @@ class WebApHelper
     bool? bytesResponse,
   }) async {
     await checkLogin();
+    final String moduleDir = '${queryQid.substring(0, 2)}_pro';
     final String url =
-        'https://webap.nkust.edu.tw/nkust/${queryQid.substring(0, 2)}_pro/$queryQid.jsp';
+        'https://webap.nkust.edu.tw/nkust/$moduleDir/$queryQid.jsp';
+    final String navUrl =
+        'https://webap.nkust.edu.tw/nkust/system/sys001_00.jsp'
+        '?spath=$moduleDir/$queryQid.jsp?';
+
+    // webap's JSP portal expects the session to have a "navigation
+    // context" for the target module before it accepts a direct POST
+    // on `*_pro/*.jsp`. A real browser establishes this by loading
+    // `sys001_00.jsp` with the matching `spath` query parameter —
+    // that's the frame the left-hand menu redirects into before the
+    // content frame loads the actual query page. Previously we only
+    // faked the Referer header pointing at sys001_00.jsp without
+    // actually fetching it, so webap treated the POST as an orphan
+    // request and returned its "session expired" error page (code 2)
+    // even though the session itself was valid. This produced the
+    // confusing pattern where ag304_01 kept failing through multiple
+    // successful logins while ag003 recovered — ag003 apparently
+    // tolerates missing nav context, ag304_01 does not.
+    //
+    // Touch the nav URL first to install the context. Response body
+    // is not consumed.
+    await dio.get<dynamic>(navUrl);
+    dio.options.headers['Referer'] = navUrl;
+
     final Options options = Options(
       contentType: 'application/x-www-form-urlencoded',
       responseType: bytesResponse != null ? ResponseType.bytes : null,
     );
-    dio.options.headers['Referer'] =
-        'https://webap.nkust.edu.tw/nkust/system/sys001_00.jsp?spath=ag_pro/$queryQid.jsp?';
 
     Response<dynamic> request;
     if (bytesResponse != null) {

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -190,9 +190,13 @@ class WebApHelper
         // way to tell apart "OCR read wrong string, server said -1" from
         // "OCR right but login succeeded and caller still sees problems
         // downstream". Printed before the switch so every branch is
-        // covered.
+        // covered. Also print the Set-Cookie header names so we can
+        // spot session-id rotation and any extra cookies webap only
+        // hands out at login time.
+        final List<String>? perchkSetCookie = res.headers['set-cookie'];
         log('[login] attempt ${i + 1}/$retryCounts: '
-            'captcha=$captchaCode perchk=$code');
+            'captcha=$captchaCode perchk=$code '
+            'setCookieCount=${perchkSetCookie?.length ?? 0}');
         switch (code) {
           case -1:
             //Captcha error, go retry.
@@ -206,6 +210,37 @@ class WebApHelper
               retryCounts: retryCounts,
             );
           case 0:
+            // webap's perchk.jsp only returns HTML that tells the
+            // browser "top.location.href='f_index.html'". The actual
+            // "session is now authenticated" state in the Tomcat
+            // backend is only finalised when the browser follows that
+            // redirect and GETs f_index.html — that's when webap
+            // stamps the JSESSIONID as an authenticated session and
+            // issues any auxiliary cookies (e.g. SKI…).
+            //
+            // Skipping this step leaves the session in an "authenticated
+            // by perchk but not promoted" limbo; any subsequent apQuery
+            // gets a 'Please Logon' redirect page and our parser reads
+            // it as code=2, triggering a full relogin cycle that keeps
+            // losing to the same issue. Just fetch the page here so
+            // the session is actually usable by the time this future
+            // resolves. Response body is not consumed.
+            try {
+              await dio.get<dynamic>(
+                'https://webap.nkust.edu.tw/nkust/f_index.html',
+                options: Options(
+                  headers: <String, String>{
+                    'Referer':
+                        'https://webap.nkust.edu.tw/nkust/perchk.jsp',
+                  },
+                ),
+              );
+            } catch (e) {
+              // Non-fatal: if the finalise GET fails transiently the
+              // caller's retry path will still fire on the next
+              // apQuery. Logged so a regression here is visible.
+              log('[login] f_index finalise GET failed: $e');
+            }
             isLogin = true;
             return LoginResponse(
               expireTime: DateTime.now().add(const Duration(hours: 6)),

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -136,25 +136,6 @@ class WebApHelper
     //
     assert(retryCounts >= 0, 'retryCounts must be >= 0');
 
-    // Clear any stale webap cookies before issuing a fresh login.
-    // Without this step the cookie jar accumulates a new JSESSIONID on
-    // every successful perchk.jsp response without ever evicting the
-    // previous one (PrivateCookieManager stores webap's non-RFC6265
-    // cookies with slightly different attributes each time, so they
-    // don't collide by name). The outgoing Cookie header then carries
-    // both copies and Tomcat picks the first — the old, now-invalid
-    // one — producing persistent "session expired" errors on every
-    // apQuery even though the login itself succeeded. Forcing a
-    // single JSESSIONID by wiping the jar first short-circuits that.
-    final List<Cookie> before = await cookieJar.loadForRequest(
-      Uri.parse('https://webap.nkust.edu.tw/'),
-    );
-    if (before.isNotEmpty) {
-      log('[login] clearing ${before.length} stale webap cookie(s) before '
-          'fresh login: ${before.map((Cookie c) => c.name).join(',')}');
-      await cookieJar.delete(Uri.parse('https://webap.nkust.edu.tw/'));
-    }
-
     // Last transient transport error seen during this login attempt.
     // Used when every captcha iteration fails due to mobile network
     // blips so the caller gets a [NetworkException] (and the UI's
@@ -210,37 +191,6 @@ class WebApHelper
               retryCounts: retryCounts,
             );
           case 0:
-            // webap's perchk.jsp only returns HTML that tells the
-            // browser "top.location.href='f_index.html'". The actual
-            // "session is now authenticated" state in the Tomcat
-            // backend is only finalised when the browser follows that
-            // redirect and GETs f_index.html — that's when webap
-            // stamps the JSESSIONID as an authenticated session and
-            // issues any auxiliary cookies (e.g. SKI…).
-            //
-            // Skipping this step leaves the session in an "authenticated
-            // by perchk but not promoted" limbo; any subsequent apQuery
-            // gets a 'Please Logon' redirect page and our parser reads
-            // it as code=2, triggering a full relogin cycle that keeps
-            // losing to the same issue. Just fetch the page here so
-            // the session is actually usable by the time this future
-            // resolves. Response body is not consumed.
-            try {
-              await dio.get<dynamic>(
-                'https://webap.nkust.edu.tw/nkust/f_index.html',
-                options: Options(
-                  headers: <String, String>{
-                    'Referer':
-                        'https://webap.nkust.edu.tw/nkust/perchk.jsp',
-                  },
-                ),
-              );
-            } catch (e) {
-              // Non-fatal: if the finalise GET fails transiently the
-              // caller's retry path will still fire on the next
-              // apQuery. Logged so a regression here is visible.
-              log('[login] f_index finalise GET failed: $e');
-            }
             isLogin = true;
             return LoginResponse(
               expireTime: DateTime.now().add(const Duration(hours: 6)),
@@ -552,31 +502,11 @@ class WebApHelper
     bool? bytesResponse,
   }) async {
     await checkLogin();
-    final String moduleDir = '${queryQid.substring(0, 2)}_pro';
     final String url =
-        'https://webap.nkust.edu.tw/nkust/$moduleDir/$queryQid.jsp';
-    final String navUrl =
-        'https://webap.nkust.edu.tw/nkust/system/sys001_00.jsp'
-        '?spath=$moduleDir/$queryQid.jsp?';
+        'https://webap.nkust.edu.tw/nkust/${queryQid.substring(0, 2)}_pro/$queryQid.jsp';
 
-    // webap's JSP portal expects the session to have a "navigation
-    // context" for the target module before it accepts a direct POST
-    // on `*_pro/*.jsp`. A real browser establishes this by loading
-    // `sys001_00.jsp` with the matching `spath` query parameter —
-    // that's the frame the left-hand menu redirects into before the
-    // content frame loads the actual query page. Previously we only
-    // faked the Referer header pointing at sys001_00.jsp without
-    // actually fetching it, so webap treated the POST as an orphan
-    // request and returned its "session expired" error page (code 2)
-    // even though the session itself was valid. This produced the
-    // confusing pattern where ag304_01 kept failing through multiple
-    // successful logins while ag003 recovered — ag003 apparently
-    // tolerates missing nav context, ag304_01 does not.
-    //
-    // Log jar state so we can verify the session cookie webap expects
-    // (typically JSESSIONID) is actually being sent. If only auxiliary
-    // cookies are present the POST was orphaned before it reached
-    // webap's session filter.
+    // Diagnostic: log which cookies the outgoing request will carry so
+    // failures downstream can be correlated with session state.
     final List<Cookie> jarCookies = await cookieJar.loadForRequest(
       Uri.parse(url),
     );
@@ -584,22 +514,12 @@ class WebApHelper
         jarCookies.map((Cookie c) => c.name).join(',');
     log('[apQuery] $queryQid: cookies=[$cookieNames]');
 
-    // Touch the nav URL first to install the context. Response body
-    // is not consumed past status/length logging.
-    final Response<dynamic> navRes = await dio.get<dynamic>(navUrl);
-    final int navBodyLen = (navRes.data is String)
-        ? (navRes.data as String).length
-        : (navRes.data is List<int>)
-            ? (navRes.data as List<int>).length
-            : -1;
-    log('[apQuery] $queryQid: nav GET → status=${navRes.statusCode} '
-        'bodyLen=$navBodyLen');
-    dio.options.headers['Referer'] = navUrl;
-
     final Options options = Options(
       contentType: 'application/x-www-form-urlencoded',
       responseType: bytesResponse != null ? ResponseType.bytes : null,
     );
+    dio.options.headers['Referer'] =
+        'https://webap.nkust.edu.tw/nkust/system/sys001_00.jsp?spath=ag_pro/$queryQid.jsp?';
 
     Response<dynamic> request;
     if (bytesResponse != null) {

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -519,9 +519,27 @@ class WebApHelper
     // successful logins while ag003 recovered — ag003 apparently
     // tolerates missing nav context, ag304_01 does not.
     //
+    // Log jar state so we can verify the session cookie webap expects
+    // (typically JSESSIONID) is actually being sent. If only auxiliary
+    // cookies are present the POST was orphaned before it reached
+    // webap's session filter.
+    final List<Cookie> jarCookies = await cookieJar.loadForRequest(
+      Uri.parse(url),
+    );
+    final String cookieNames =
+        jarCookies.map((Cookie c) => c.name).join(',');
+    log('[apQuery] $queryQid: cookies=[$cookieNames]');
+
     // Touch the nav URL first to install the context. Response body
-    // is not consumed.
-    await dio.get<dynamic>(navUrl);
+    // is not consumed past status/length logging.
+    final Response<dynamic> navRes = await dio.get<dynamic>(navUrl);
+    final int navBodyLen = (navRes.data is String)
+        ? (navRes.data as String).length
+        : (navRes.data is List<int>)
+            ? (navRes.data as List<int>).length
+            : -1;
+    log('[apQuery] $queryQid: nav GET → status=${navRes.statusCode} '
+        'bodyLen=$navBodyLen');
     dio.options.headers['Referer'] = navUrl;
 
     final Options options = Options(
@@ -545,17 +563,33 @@ class WebApHelper
     }
 
     if (WebApParser.instance.apLoginParser(request.data) == 2) {
-      // Helps tell apart a short 302 redirect body (session truly gone
-      // on server side) from a full login page HTML (cookie didn't
-      // reach the server, or jar didn't persist). Logged only on the
-      // failure path to avoid noise.
+      // Include a preview of the first few hundred chars of the body.
+      // That's enough to distinguish a short 302 html, a login page, a
+      // <script>location.href=...</script> redirect stub, or whatever
+      // other flavour webap is sending; current header-only logging
+      // can't tell them apart.
+      final String bodyStr = (request.data is String)
+          ? request.data as String
+          : (request.data is List<int>)
+              ? String.fromCharCodes((request.data as List<int>).take(400))
+              : '';
       final int bodyLen = (request.data is String)
           ? (request.data as String).length
           : (request.data is List<int>)
               ? (request.data as List<int>).length
               : -1;
+      final String preview = bodyStr.length > 400
+          ? bodyStr.substring(0, 400)
+          : bodyStr;
+      // Collapse whitespace so the preview fits on one log line.
+      final String previewOneLine = preview
+          .replaceAll('\r', ' ')
+          .replaceAll('\n', ' ')
+          .replaceAll(RegExp(r'\s+'), ' ')
+          .trim();
       log('[apQuery] $queryQid → code=2 session expired '
           '(status=${request.statusCode} bodyLen=$bodyLen)');
+      log('[apQuery] $queryQid body preview: $previewOneLine');
       throw const ApSessionExpiredException();
     }
     return request;

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -211,7 +211,7 @@ class WebApHelper
         // Truly unexpected errors (parser bugs, etc.) are logged and
         // allowed to trigger another captcha attempt.
         CrashlyticsUtil.instance.recordError(e, s);
-        log(e.toString());
+        log('[login] attempt ${i + 1}/$retryCounts: $e');
       }
     }
     //

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -136,6 +136,25 @@ class WebApHelper
     //
     assert(retryCounts >= 0, 'retryCounts must be >= 0');
 
+    // Clear any stale webap cookies before issuing a fresh login.
+    // Without this step the cookie jar accumulates a new JSESSIONID on
+    // every successful perchk.jsp response without ever evicting the
+    // previous one (PrivateCookieManager stores webap's non-RFC6265
+    // cookies with slightly different attributes each time, so they
+    // don't collide by name). The outgoing Cookie header then carries
+    // both copies and Tomcat picks the first — the old, now-invalid
+    // one — producing persistent "session expired" errors on every
+    // apQuery even though the login itself succeeded. Forcing a
+    // single JSESSIONID by wiping the jar first short-circuits that.
+    final List<Cookie> before = await cookieJar.loadForRequest(
+      Uri.parse('https://webap.nkust.edu.tw/'),
+    );
+    if (before.isNotEmpty) {
+      log('[login] clearing ${before.length} stale webap cookie(s) before '
+          'fresh login: ${before.map((Cookie c) => c.name).join(',')}');
+      await cookieJar.delete(Uri.parse('https://webap.nkust.edu.tw/'));
+    }
+
     // Last transient transport error seen during this login attempt.
     // Used when every captcha iteration fails due to mobile network
     // blips so the caller gets a [NetworkException] (and the UI's
@@ -571,15 +590,15 @@ class WebApHelper
       final String bodyStr = (request.data is String)
           ? request.data as String
           : (request.data is List<int>)
-              ? String.fromCharCodes((request.data as List<int>).take(400))
+              ? String.fromCharCodes((request.data as List<int>).take(1500))
               : '';
       final int bodyLen = (request.data is String)
           ? (request.data as String).length
           : (request.data is List<int>)
               ? (request.data as List<int>).length
               : -1;
-      final String preview = bodyStr.length > 400
-          ? bodyStr.substring(0, 400)
+      final String preview = bodyStr.length > 1500
+          ? bodyStr.substring(0, 1500)
           : bodyStr;
       // Collapse whitespace so the preview fits on one log line.
       final String previewOneLine = preview

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -95,7 +95,7 @@ class WebApHelper
   Future<LoginResponse> login({
     required String username,
     required String password,
-    int retryCounts = 5,
+    int retryCounts = 8,
   }) async {
     if (_loginInProgress != null) {
       return _loginInProgress!.future;
@@ -122,7 +122,7 @@ class WebApHelper
   Future<LoginResponse> _doLogin({
     required String username,
     required String password,
-    int retryCounts = 5,
+    int retryCounts = 8,
   }) async {
     //
     /*
@@ -167,6 +167,13 @@ class WebApHelper
         Helper.username = username;
         Helper.password = password;
         final int code = WebApParser.instance.apLoginParser(res.data);
+        // Observability: knowing the perchk code per attempt is the only
+        // way to tell apart "OCR read wrong string, server said -1" from
+        // "OCR right but login succeeded and caller still sees problems
+        // downstream". Printed before the switch so every branch is
+        // covered.
+        log('[login] attempt ${i + 1}/$retryCounts: '
+            'captcha=$captchaCode perchk=$code');
         switch (code) {
           case -1:
             //Captcha error, go retry.
@@ -516,6 +523,17 @@ class WebApHelper
     }
 
     if (WebApParser.instance.apLoginParser(request.data) == 2) {
+      // Helps tell apart a short 302 redirect body (session truly gone
+      // on server side) from a full login page HTML (cookie didn't
+      // reach the server, or jar didn't persist). Logged only on the
+      // failure path to avoid noise.
+      final int bodyLen = (request.data is String)
+          ? (request.data as String).length
+          : (request.data is List<int>)
+              ? (request.data as List<int>).length
+              : -1;
+      log('[apQuery] $queryQid → code=2 session expired '
+          '(status=${request.statusCode} bodyLen=$bodyLen)');
       throw const ApSessionExpiredException();
     }
     return request;

--- a/lib/api/api_config.dart
+++ b/lib/api/api_config.dart
@@ -15,8 +15,15 @@ class ApiConfig {
   static const int maxRetries = 3;
   static const Duration retryDelay = Duration(milliseconds: 500);
 
+  // Experiment: webap appears to treat the previous Mac-Chrome UA
+  // string as non-interactive traffic and returns its
+  // "Please Logon" redirect page on every apQuery even after a
+  // successful perchk.jsp handshake. Switch to a plain Android Chrome
+  // mobile UA — the same shape a student actually browsing webap on
+  // their phone would send — and see whether the behaviour changes.
   static const String defaultUserAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+      'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 '
+      '(KHTML, like Gecko) Chrome/131.0.0.0 Mobile Safari/537.36';
 
   static Dio createDio({
     String? baseUrl,

--- a/lib/api/relogin_mixin.dart
+++ b/lib/api/relogin_mixin.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer';
 
 /// Mixin for handling session-level re-login when a scraper session expires.
 ///
@@ -83,6 +84,17 @@ mixin ReloginMixin {
   /// the race-condition timestamp and the [onReloginSuccess] broadcast stay
   /// consistent whether the login was triggered by top-level `login()` or
   /// by this method.
+  /// How many initial session-expired errors should skip relogin when a
+  /// successful login happened within [recentLoginWindow]. webap
+  /// occasionally returns code 2 on the first query after a fresh
+  /// session, and a short backoff is enough to recover without burning
+  /// a captcha. Kept intentionally small (2) — observations show that
+  /// if the first 1–2 retries don't recover the session, waiting
+  /// longer doesn't help and only the real relogin path does. This
+  /// budget is tracked SEPARATELY from [maxRelogins] so race-retry
+  /// never starves the relogin path.
+  static const int _raceConditionAttemptLimit = 2;
+
   Future<T> withAutoRelogin<T>({
     required Future<T> Function() action,
     required Future<void> Function() relogin,
@@ -90,25 +102,38 @@ mixin ReloginMixin {
     Duration retryDelay = const Duration(milliseconds: 500),
     Duration recentLoginWindow = const Duration(seconds: 30),
   }) async {
-    int attempts = 0;
+    int raceAttempts = 0;
+    int reloginAttempts = 0;
     while (true) {
       try {
         return await action();
       } catch (e) {
-        if (!isSessionExpired(e) || attempts >= maxRelogins) rethrow;
-        attempts++;
+        if (!isSessionExpired(e)) rethrow;
 
         final bool recentlyLoggedIn = _lastSuccessfulRelogin != null &&
             DateTime.now().difference(_lastSuccessfulRelogin!) <
                 recentLoginWindow;
+        log('[withAutoRelogin] race=$raceAttempts/$_raceConditionAttemptLimit '
+            'relogin=$reloginAttempts/$maxRelogins '
+            'recentlyLoggedIn=$recentlyLoggedIn '
+            'trigger=${e.runtimeType}');
 
-        if (recentlyLoggedIn && attempts <= 1) {
-          // First retry after a recent login — likely a server race
-          // condition (#342), not real session expiry. Just delay and
-          // retry the request without re-authenticating.
-          await Future<void>.delayed(retryDelay);
+        if (recentlyLoggedIn &&
+            raceAttempts < _raceConditionAttemptLimit) {
+          // Short-circuit for the small server-side session-propagation
+          // race (#342). Delay with exponential backoff (500ms → 1000ms)
+          // and retry the same request without re-authenticating.
+          raceAttempts++;
+          final Duration delay = retryDelay * raceAttempts;
+          log('[withAutoRelogin] → race-retry $raceAttempts/$_raceConditionAttemptLimit delay=${delay.inMilliseconds}ms');
+          await Future<void>.delayed(delay);
           continue;
         }
+
+        // Race budget exhausted (or we never qualified) — the session is
+        // genuinely gone and only a real relogin will recover it.
+        if (reloginAttempts >= maxRelogins) rethrow;
+        reloginAttempts++;
 
         // Single-flight relogin: piggy-back on any in-progress relogin.
         // If it fails (e.g. wrong password), propagate the same failure to
@@ -116,11 +141,13 @@ mixin ReloginMixin {
         // and trigger redundant captcha attempts.
         final Completer<void>? inFlight = _reloginInFlight;
         if (inFlight != null) {
+          log('[withAutoRelogin] → await in-flight relogin');
           await inFlight.future;
           await Future<void>.delayed(retryDelay);
           continue;
         }
 
+        log('[withAutoRelogin] → relogin $reloginAttempts/$maxRelogins');
         final Completer<void> completer = Completer<void>();
         _reloginInFlight = completer;
         try {


### PR DESCRIPTION
## 摘要

把登入流程的三類可靠性問題合併在一個 PR 處理。原本 #398（transient 網路重試）的變更 cherry-pick 到本分支，所以 #398 已 close by this PR。

## 三層修正

### 1. Transient 網路抖動時繼續 captcha 迴圈（原 #398）

\`_doLogin\` 原本任何 DioException 就整個放棄。區分 transient（connectionTimeout / sendTimeout / receiveTimeout / connectionError）跟 terminal（cancel / badResponse / badCertificate）：

- Transient：記下來、delay 1s、繼續 loop，下次 iteration 再試
- Terminal：立刻 rethrow
- 迴圈全失敗但有過 transient → 最終丟 \`NetworkException\` 而非 \`CaptchaException\`，讓 UI 的 offline-login fallback 仍能 fire

### 2. `withAutoRelogin` 的 race-retry / relogin 分開記帳

實測發現原本 `attempts <= 1` 太小、改成 `<= 3` 又會「race-retry 吃光 maxRelogins」。分開兩個 counter：

- `raceAttempts` 上限 2（exponential backoff 500ms → 1000ms），只在 `recentlyLoggedIn` 時啟用
- `reloginAttempts` 照舊用 `maxRelogins`（3）
- 總預算：2 次 race + 3 次 relogin，使用者 5–10 秒內完整恢復
- **關鍵**：不會再出現「race-retry 吃光預算後直到 30 秒過後才能 relogin」的死等

### 3. 診斷觀察性增強 + captcha retry 上限 5→8

最新一輪 log 顯示「5 次 OCR 都成功、但 login 還是通通失敗」，又或「login 看似成功、apQuery 仍 code 2」。單看 log 不夠分辨是 OCR 辨識錯、cookie 沒存、或 302 被當 body。加兩條診斷：

\`\`\`
[login] attempt 3/8: captcha=7YEE perchk=-1
[apQuery] ag304_01 → code=2 session expired (status=200 bodyLen=532)
\`\`\`

- perchk code 直接印在每次 attempt，知道是 OCR 錯還是其他錯
- apQuery code 2 時印出 response length，短 body 通常代表 302 redirect 被當 body、長 body 代表收到完整 login page HTML

同時把 `retryCounts` 預設 5 → 8。實測 OCR 通過率大約 50%，5 次約 97%、8 次約 99.6%，最壞多 2 秒等待時間，但使用者少看到一次 captcha 失敗 toast。

## Commit 順序

1. `8d449a10 fix(login): split race-retry and relogin budgets in withAutoRelogin`
2. `a6853078 fix(login): retry captcha loop on transient network errors`（原 #398，cherry-pick）
3. `83583224 fix(login): add perchk/apQuery diagnostics and bump captcha retry budget`

## 後續預期

此 PR 合併後，下一輪實測 log 會清楚告訴我們根因是：
- (a) OCR 辨識率問題 → 需要換模型 / 重訓字典
- (b) Cookie jar 不保存 webap 的 Set-Cookie → 要改 PrivateCookieManager
- (c) apQuery 平行呼叫搞亂 `dio.options.headers` → 需要 per-request headers 而非 mutate 全域

本 PR 不修 (a)(b)(c) — 等實測數據判斷再開對應 PR。

## Test plan

- [x] \`fvm flutter analyze\` — 0 new errors
- [x] \`fvm flutter test test/api_parser_test.dart\` — 29/29 通過
- [ ] CI 綠燈
- [ ] 實機 smoke：
  - [ ] 登入 → HomePage UserInfo 正常載入
  - [ ] 登入後立刻點課表 → 成功載入
  - [ ] logcat 應看到 `[login] attempt N/8: captcha=XXXX perchk=<code>` 與 `[apQuery] ... bodyLen=X`
  - [ ] 飛航模式測試 transient retry（延續 #398 的 test plan）

## 關聯

- #342 ReloginMixin 原始實作
- #398（已關閉、其 commit 已 cherry-pick 到本 PR）