### PR TITLE
chore(android): debug build 信任使用者安裝的 CA

### DIFF
--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,5 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
+    <!-- debug-overrides only apply when the APK is built with
+         android:debuggable="true". Release builds ignore this block
+         entirely, so production continues to pin only @raw/twca_nkust
+         plus system CAs. Lets us plug in Charles / Proxyman / mitmproxy
+         via a user-added CA for HTTPS inspection without touching the
+         production trust chain. -->
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user"/>
+            <certificates src="system"/>
+        </trust-anchors>
+    </debug-overrides>
+
     <domain-config>
         <domain includeSubdomains="true">webap.nkust.edu.tw</domain>
         <domain includeSubdomains="true">mobile.nkust.edu.tw</domain>


### PR DESCRIPTION
### **User description**
## 摘要

為了用 Charles / Proxyman / mitmproxy 抓 webap / stdsys / vms 等 NKUST 流量做 debug，debug build 需要信任**使用者自行安裝的 CA**（proxy 的 root CA 會落在 user store）。加一個 \`<debug-overrides>\` block 讓這個放寬**只對 debug APK 生效** — release build 會完全忽略這個 block，照舊只 pin \`@raw/twca_nkust\` + system trust store。

## 變更

只動一個檔：\`android/app/src/main/res/xml/network_security_config.xml\`

\`\`\`xml
<debug-overrides>
    <trust-anchors>
        <certificates src="user"/>
        <certificates src="system"/>
    </trust-anchors>
</debug-overrides>
\`\`\`

## Release 受影響嗎

不會。Android 平台保證 \`debug-overrides\` 只有在 APK 以 \`android:debuggable=\"true\"\` 打出來時才生效（也就是 \`flutter run\` 跟 debug APK）。Release APK 編譯完成後這個 block 等同不存在，trust chain 仍然：

- 對 NKUST 八個網域：\`@raw/twca_nkust\` + system
- 其他：預設 system

## 重要限制：Cronet 不理這個設定

本專案 Android 用 \`native_dio_adapter\` → 走 **Cronet**。Cronet 有自己的 cert store、**不會讀 \`networkSecurityConfig\`**。所以光加這段還不夠 — 要實際抓 webap / stdsys 流量，debug 時還得同時改 \`ApiConfig.createDio\` 關掉 \`useNativeAdapter\`（或用 \`kDebugMode\` 條件化），讓流量走純 Dart \`HttpClient\`，才會真的走 proxy 並驗 user CA。

那一步**不在本 PR 範圍**，需要時另外開 PR 或本地 patch。

## Test plan

- [x] \`flutter analyze\` — 0 errors（本 PR 純 XML，無 Dart 改動）
- [x] Debug build 下裝 mitmproxy CA，搭配關閉 native adapter 的本地 patch，確認能看到 NKUST HTTPS 明文
- [x] Release build APK 用 apk-analyzer 或 aapt 檢查 \`network_security_config.xml\` 於實際執行時是否仍維持 pin-only 行為（可做可不做，Android 平台保證）


___

### **PR Type**
Enhancement


___

### **Description**
- 允許偵錯版本信任使用者安裝的 CA

- 透過 `network-security-config.xml` 實現

- 僅影響偵錯版本，不影響發布版本

- 支援 HTTPS 流量檢查工具


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["偵錯 APK"] -- "信任" --> B["使用者安裝的 CA"]
  B -- "啟用" --> C["HTTPS 流量檢查 (Charles/Proxyman)"]
  D["發布 APK"] -- "忽略" --> B
```

