### PR TITLE
fix(android): 依 gal 套件規格對齊相簿儲存權限

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,9 +4,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <!-- Storage permissions for saving course table screenshots -->
+    <!-- Storage permissions for saving course table screenshots to album (gal package) -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
+        android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <!-- Permissions options for the Android 14 alarm `flutter_local_notification` -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"
@@ -31,6 +31,7 @@
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"
         android:enableOnBackInvokedCallback="true"
+        android:requestLegacyExternalStorage="true"
         android:networkSecurityConfig="@xml/network_security_config">
 
         <meta-data


### PR DESCRIPTION
### **User description**
## Summary

依 [\`gal\`](https://pub.dev/packages/gal) 套件 README 的 Android 設定校正 \`AndroidManifest.xml\`：

| 項目 | Before | After |
|---|---|---|
| \`WRITE_EXTERNAL_STORAGE\` 的 \`maxSdkVersion\` | \`32\` | \`29\`（符合 gal 規格） |
| \`<application>\` 的 \`requestLegacyExternalStorage\` | 未設定 | \`"true"\` |

## Why

- \`gal\` 官方規格：API ≤ 29（Android 10 以下）才需 \`WRITE_EXTERNAL_STORAGE\`，並搭配 \`requestLegacyExternalStorage="true"\` 讓 Android 10 仍能以舊式檔案 API 寫入相簿。
- 之前把 \`maxSdkVersion\` 放寬到 32 是歷史遺留；在 \`READ_MEDIA_IMAGES\`（API 33+）已經存在的情況下，對齊 gal 推薦的 29 比較精準、也避免 Play Console 對不必要權限的警告。

## Test plan

- [ ] \`flutter build apk --release\` 仍然成功
- [ ] Android 10 裝置 / 模擬器：課表截圖匯出至相簿成功
- [ ] Android 13+ 裝置：課表截圖匯出至相簿成功（走 \`READ_MEDIA_IMAGES\` / MediaStore）
- [ ] Play Console 權限宣告頁無新的警告


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 調整 `WRITE_EXTERNAL_STORAGE` 權限 `maxSdkVersion`。

- 新增 `requestLegacyExternalStorage="true"` 屬性。

- 符合 `gal` 套件的 Android 儲存規範。

- 避免 Play Console 權限警告。


___

