### PR TITLE
chore(android): 升 AGP 到 8.8.2、Kotlin 到 2.1.20

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -22,9 +22,9 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.5.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.20" apply false
-    id "org.jetbrains.kotlin.plugin.compose" version "2.0.20" apply false
+    id "com.android.application" version "8.8.2" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.20" apply false
+    id "org.jetbrains.kotlin.plugin.compose" version "2.1.20" apply false
     id("com.google.gms.google-services") version("4.4.3") apply false
     id "com.google.firebase.crashlytics" version "2.8.1" apply false
 }


### PR DESCRIPTION
## Summary

消除 Flutter 3.41 的 Android toolchain deprecation warning：

| 項目 | Before | After | Flutter 警告門檻 |
|---|---|---|---|
| Android Gradle Plugin | \`8.5.1\` | \`8.8.2\` | ≥ \`8.6.0\` |
| Kotlin (android / compose plugin) | \`2.0.20\` | \`2.1.20\` | ≥ \`2.1.0\` |

## Why 8.8.2 + 2.1.20（不是 8.13 / 2.2）

| 元件 | 狀態 |
|---|---|
| AGP 8.8.x 需要 Gradle | \`8.10.2+\` |
| 目前 Gradle wrapper | \`8.10.2\` ✅ |

走這個組合**不用動 \`gradle-wrapper.properties\`**，改動面最小：

- ≥ 8.9 會需要 Gradle 8.11.1+，要同步升 wrapper
- ≥ 8.12 會要求 Java 21（CI 已經是 Java 21，但 8.12+ 還有其他 sealed API 的變動）

先穩穩跨過 Flutter 警告門檻，之後有需要再走 Gradle + AGP 13 的大升級。

## Files

- \`android/settings.gradle\` — plugins DSL 版本更新

## Test plan

- [x] \`flutter clean && flutter pub get && flutter build apk --debug\` 本機跑過（Gradle task \`assembleDebug\` 84.5s 完成，無 warning）
- [ ] CI \`Build Android App\` 綠燈
- [ ] Release build（CD 合進去後）能順利打出 appbundle
- [ ] Play Console 內 crash-free 數據無突升