### PR TITLE
fix(ci): Android deploy 改用 runner 預裝 fastlane（對齊 iOS）

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,13 +95,15 @@ jobs:
       - run: flutter pub get
       - name: Build Android app bundle
         run: flutter build appbundle --release --build-number=${{ needs.prepare.outputs.version_code }}
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-      - name: Install Fastlane
-        run: gem install fastlane fastlane-plugin-flutter_version
       - name: Run Fastlane
+        # Self-hosted runner ships fastlane + fastlane-plugin-flutter_version
+        # pre-installed (same assumption the iOS deploy job makes). On
+        # GitHub-hosted ubuntu this job used `ruby/setup-ruby@v1` + a
+        # `gem install` step; on the self-hosted macOS runner those steps
+        # failed because ruby/setup-ruby@v1 tries to mkdir /Users/runner
+        # (the GitHub-hosted runner's home), which the self-hosted user
+        # (rainvisitor) doesn't own — EACCES. Mirror the iOS setup
+        # instead: just invoke the system fastlane directly.
         run: fastlane ${{ needs.prepare.outputs.is_production == 'true' && 'playstore' || 'beta' }}
         working-directory: ./android
 


### PR DESCRIPTION
### **User description**
## 摘要

自從 PR #404 把 Android deploy 的 runner 從 \`ubuntu-latest\` 改成 \`[self-hosted, android, macOS]\`，每次都死在 fastlane 之前：

\`\`\`
/Users/runner/hostedtoolcache/Ruby/3.3.11/arm64/bin
##[error]Error: EACCES: permission denied, mkdir '/Users/runner'
\`\`\`

根因：\`ruby/setup-ruby@v1\` 硬寫 tool cache 路徑 \`/Users/runner/\`（GitHub-hosted Mac runner 的 user home）。自架 Mac 的 login user 是 \`rainvisitor\`，沒權限建 \`/Users/runner\` → EACCES。

## 修法

對齊 iOS deploy 的做法 —— iOS job 已經假設 **self-hosted runner 預裝 fastlane + 相關 plugin**，直接跑 \`fastlane\` 即可，沒有 \`ruby/setup-ruby\` / \`gem install\` 那些 step。

本 PR 把 Android 的相同兩步拿掉：

\`\`\`diff
- - name: Setup Ruby
-   uses: ruby/setup-ruby@v1
-   with:
-     ruby-version: '3.3'
- - name: Install Fastlane
-   run: gem install fastlane fastlane-plugin-flutter_version
  - name: Run Fastlane
    run: fastlane ${{ needs.prepare.outputs.is_production == 'true' && 'playstore' || 'beta' }}
\`\`\`

## 前提

Self-hosted runner（\`rainvisitor\` 的 Mac）需要**預裝**：
- ruby + bundler
- fastlane
- fastlane-plugin-flutter_version

iOS deploy job 已經在吃這個假設、能跑通，所以這些套件在 runner 上**早就存在**，不需額外 setup。

## 淨效果

- 拿掉 2 步
- Android CD 不再死在 EACCES
- macOS 失敗跟這個無關（是另一條 provisioning profile 問題）

## Test plan

- [ ] 合併後下次 push develop → Android job 綠燈、APK 上 internal testing


___

### **PR Type**
Bug fix


___

### **Description**
- 修復 Android CI/CD 部署錯誤。

- 移除 Ruby 設定與 Fastlane 安裝。

- 改用自託管執行器預裝 Fastlane。

- 解決權限問題，對齊 iOS 部署。


___

