### PR TITLE
fix(ci): macOS CD 自動下載 provisioning profile + 簽章 .app

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -175,6 +175,13 @@ jobs:
       - name: Flutter Initialize
         run: flutter doctor -v
       - run: flutter pub get
+      - name: Clean previous signing keychains (self-hosted idempotency)
+        # Self-hosted runners keep ~/Library/Keychains between jobs, so
+        # apple-actions/import-codesign-certs fails on the second run
+        # with exit 48 ("A keychain with the same name already exists").
+        run: |
+          security delete-keychain mac-installer-signing.keychain 2>/dev/null || true
+          security delete-keychain mac-app-signing.keychain 2>/dev/null || true
       - name: Import Mac Installer Distribution certificate
         uses: apple-actions/import-codesign-certs@v3
         with:
@@ -182,14 +189,56 @@ jobs:
           p12-password: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
           keychain: mac-installer-signing
           keychain-password: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
-      - name: Verify Installer Distribution identity is available
+      - name: Import Mac App Distribution certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MAC_APP_CERT_BASE64 }}
+          p12-password: ${{ secrets.MAC_APP_CERT_PASSWORD }}
+          keychain: mac-app-signing
+          keychain-password: ${{ secrets.MAC_APP_CERT_PASSWORD }}
+          create-keychain: true
+      - name: Consolidate keychain search list
+        # Each apple-actions/import-codesign-certs@v3 run rewrites the
+        # user-domain search list to `<its keychain> login`, which
+        # evicts the previous custom keychain. Re-add both so every
+        # subsequent security/codesign/productbuild lookup sees both
+        # identities.
         run: |
+          security list-keychains -d user -s \
+            mac-installer-signing.keychain \
+            mac-app-signing.keychain \
+            login.keychain
+          security list-keychains -d user
+      - name: Verify Mac signing identities are available
+        run: |
+          missing=0
           if ! security find-identity -v | grep -q "3rd Party Mac Developer Installer"; then
-            echo "::error::3rd Party Mac Developer Installer identity not found in any keychain after import. Verify MAC_INSTALLER_CERT_BASE64 / MAC_INSTALLER_CERT_PASSWORD secrets contain a valid Installer Distribution .p12."
+            echo "::error::3rd Party Mac Developer Installer identity missing. Check MAC_INSTALLER_CERT_BASE64 / MAC_INSTALLER_CERT_PASSWORD."
+            missing=1
+          fi
+          if ! security find-identity -v | grep -q "3rd Party Mac Developer Application"; then
+            echo "::error::3rd Party Mac Developer Application identity missing. Check MAC_APP_CERT_BASE64 / MAC_APP_CERT_PASSWORD."
+            missing=1
+          fi
+          if [ "$missing" = "1" ]; then
             security find-identity -v || true
             exit 1
           fi
-          security find-identity -v | grep "3rd Party Mac Developer Installer"
+          security find-identity -v | grep "3rd Party Mac Developer"
+      - name: Download Mac App Store provisioning profile
+        # Pull the Mac App Store Distribution provisioning profile via
+        # the Connect API rather than committing it to the repo. The
+        # action drops the .provisionprofile under
+        # ~/Library/MobileDevice/Provisioning Profiles/ with a UUID
+        # filename. We copy it into the .app bundle after build, before
+        # codesign seals the Contents hash.
+        uses: apple-actions/download-provisioning-profiles@v4
+        with:
+          bundle-id: com.nkust.ap.flutter
+          profile-type: MAC_APP_STORE
+          issuer-id: ${{ secrets.APP_STORE_CONNECT_API_API_ISSUER_ID }}
+          api-key-id: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          api-private-key: ${{ secrets.APP_STORE_CONNECT_API_KEY_PEM }}
       - name: Generate changelog
         run: bash "$GITHUB_WORKSPACE/.github/scripts/generate_changelog.sh" ${{ needs.prepare.outputs.version_code }} macos
         working-directory: ./macos/fastlane
@@ -197,6 +246,47 @@ jobs:
           AGGREGATED_CHANGELOG: ${{ github.workspace }}/changelog_aggregated.json
       - name: Build macOS
         run: flutter build macos --release --build-number=${{ needs.prepare.outputs.version_code }}
+      - name: Embed provisioning profile and codesign .app
+        # `flutter build macos --release` produces an unsigned (or
+        # ad-hoc-signed) .app. For App Store upload we need to:
+        #   1. Copy the downloaded MAC_APP_STORE profile into the
+        #      bundle as Contents/embedded.provisionprofile so altool's
+        #      "profile included in the bundle" check matches.
+        #   2. Re-sign with the 3rd Party Mac Developer Application
+        #      identity and the Release.entitlements (which declares
+        #      com.apple.security.app-sandbox=true, required for App
+        #      Store submission).
+        # Order matters: profile must land before codesign seals the
+        # _CodeSignature directory; otherwise the signature invalidates
+        # the moment we drop a new file into Contents/.
+        env:
+          MAC_APP_DISTRIBUTION_CERT_NAME: ${{ secrets.MAC_APP_DISTRIBUTION_CERT_NAME }}
+        run: |
+          APP_PATH="$(find build/macos/Build/Products/Release -maxdepth 1 -type d -name '*.app' | head -n1)"
+          if [ -z "$APP_PATH" ]; then
+            echo "::error::No .app bundle found under build/macos/Build/Products/Release"
+            exit 1
+          fi
+          echo "App bundle: $APP_PATH"
+
+          PROFILE_SRC="$(find "$HOME/Library/MobileDevice/Provisioning Profiles" -maxdepth 1 -type f -name '*.provisionprofile' | head -n1)"
+          if [ -z "$PROFILE_SRC" ]; then
+            echo "::error::No provisioning profile found under ~/Library/MobileDevice/Provisioning Profiles/ — download step didn't land anything."
+            exit 1
+          fi
+          echo "Embedding profile: $PROFILE_SRC"
+          cp "$PROFILE_SRC" "$APP_PATH/Contents/embedded.provisionprofile"
+
+          codesign --force --deep --options runtime --timestamp \
+            --entitlements macos/Runner/Release.entitlements \
+            --sign "$MAC_APP_DISTRIBUTION_CERT_NAME" \
+            "$APP_PATH"
+          codesign --verify --verbose=2 "$APP_PATH"
+          codesign --display --entitlements :- "$APP_PATH" | \
+            grep -q "com.apple.security.app-sandbox" || {
+              echo "::error::app-sandbox entitlement missing from signed .app"
+              exit 1
+            }
       - name: Decode API Key
         run: |
           echo "${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}" | base64 --decode > macos/AuthKey.p8


### PR DESCRIPTION
### **User description**
## 摘要

目前 macOS CD 在 altool 上傳時被退：

\`\`\`
[altool] Validation failed (409) Invalid Provisioning Profile.
The provisioning profile included in the bundle com.nkust.ap.flutter
[...] is invalid. [Missing code-signing certificate.]
\`\`\`

App Store 上架的三個環節必須同步：

| 環節 | 需要 | 目前狀態 |
|---|---|---|
| `.app` 簽章 | 3rd Party Mac Developer Application 憑證 | ❌ Xcode 自動走 Apple Development |
| `.app` 夾帶 provisioning profile | 對應 bundle id + 同簽章 cert 的 .provisionprofile | ❌ 沒夾 |
| `.pkg` 簽章 | Installer Distribution 憑證 | ✅ fastlane productbuild 已處理 |

過去只做第三個。\`flutter build macos --release\` 產出的 .app 既沒 Distribution 簽章、也沒 embedded profile，altool 看一眼就退，再怎麼換 cert 也沒用。本 PR 補上前兩個。

## 變更

### 1. 匯入 App Distribution 憑證（新）

除既有 Installer cert 匯入外，再加一個 App Distribution 憑證的 \`apple-actions/import-codesign-certs@v3\` 步驟，放進獨立的 \`mac-app-signing\` keychain。

### 2. Self-hosted 冪等化

跑 \`apple-actions/import-codesign-certs@v3\` 前先：

\`\`\`bash
security delete-keychain mac-installer-signing.keychain 2>/dev/null || true
security delete-keychain mac-app-signing.keychain 2>/dev/null || true
\`\`\`

避免 self-hosted 第二次跑撞 \`security create-keychain\` exit 48（keychain 已存在）。

### 3. 合併 keychain 搜尋列表

每次 \`apple-actions/import-codesign-certs@v3\` 都會把搜尋列表改成 \`<自己的 keychain> login\`，所以**第二個 import 會把第一個趕出搜尋列表**。加一步重設：

\`\`\`bash
security list-keychains -d user -s \\
  mac-installer-signing.keychain \\
  mac-app-signing.keychain \\
  login.keychain
\`\`\`

### 4. 透過 Connect API 下載 provisioning profile（新）

\`\`\`yaml
- uses: apple-actions/download-provisioning-profiles@v4
  with:
    bundle-id: com.nkust.ap.flutter
    profile-type: MAC_APP_STORE
    issuer-id: \${{ secrets.APP_STORE_CONNECT_API_API_ISSUER_ID }}
    api-key-id: \${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
    api-private-key: \${{ secrets.APP_STORE_CONNECT_API_KEY_PEM }}
\`\`\`

每次 run 抓最新的 profile，不需 commit 進 repo，未來換 cert 也自動跟上。

### 5. Build 後：copy profile + codesign（新）

\`\`\`bash
APP_PATH="$(find build/macos/Build/Products/Release -maxdepth 1 -type d -name '*.app' | head -n1)"
PROFILE="$(find ~/Library/MobileDevice/Provisioning\\ Profiles -name '*.provisionprofile' | head -n1)"
cp "$PROFILE" "$APP_PATH/Contents/embedded.provisionprofile"
codesign --force --deep --options runtime --timestamp \\
  --entitlements macos/Runner/Release.entitlements \\
  --sign "$MAC_APP_DISTRIBUTION_CERT_NAME" \\
  "$APP_PATH"
codesign --verify --verbose=2 "$APP_PATH"
codesign --display --entitlements :- "$APP_PATH" | grep -q app-sandbox
\`\`\`

順序重要：**profile 必須在 codesign 之前 copy 進 Contents/**，不然 \`_CodeSignature\` 封印的內容 hash 會因為後來新增檔案而失效。

Fastlane 後面的 \`productbuild --sign "<Installer>"\` 不動，繼續把 signed .app 包 .pkg。

## 需要你加的 Secrets

| Secret | 內容 |
|---|---|
| \`MAC_APP_CERT_BASE64\` | \`3rd Party Mac Developer Application\` \`.p12\` 的 base64（\`base64 -i mac_app_distribution.p12 \| pbcopy\`） |
| \`MAC_APP_CERT_PASSWORD\` | 該 .p12 匯出密碼 |
| \`MAC_APP_DISTRIBUTION_CERT_NAME\` | 憑證 common name，例：\`3rd Party Mac Developer Application: Open Culture Foundation (XXXXXXXXXX)\` |
| \`APP_STORE_CONNECT_API_KEY_PEM\` | **raw PEM 內容**（打開 .p8 複製整份，包含 \`-----BEGIN PRIVATE KEY-----\` 行） |

既有的 \`APP_STORE_CONNECT_API_KEY_BASE64\` 保留，Fastlane 後面 \`base64 --decode > AuthKey.p8\` 仍會用到。

## 還要做的 Developer Portal 動作

Connect API 下載回來的 profile 要**包含你現在 keychain 用的 App Distribution cert**。請確認：

1. 進 <https://developer.apple.com/account/resources/profiles/list>
2. 找 \`com.nkust.ap.flutter\` 的 **Mac App Store Distribution** profile
3. Edit → 勾選**目前正用的 \`3rd Party Mac Developer Application\` 憑證**
4. Save/Regenerate

沒 regenerate 的話下載回來的 profile 還是記著舊 cert → altool 仍然會退。

## Test plan

- [ ] 設定 4 個新 secret
- [ ] Developer Portal 上 regenerate profile
- [ ] 觀察下次 CD 的 \`deploy_macos\` job：
  - [ ] 兩個 cert import 都成功
  - [ ] \`Verify Mac signing identities are available\` 看到兩顆
  - [ ] \`Download Mac App Store provisioning profile\` 有拉到檔案
  - [ ] \`Embed provisioning profile and codesign .app\` 印出 app-sandbox 驗證通過
  - [ ] Fastlane upload_to_testflight 成功、TestFlight 收到新 build

## 關聯

- 前置：Android deploy fastlane 修正 PR #405（兩者觸碰同檔，可併)  
- Refs #312


___

### **PR Type**
Bug fix


___

### **Description**
- 解決 macOS CD 部署簽章問題。

- 匯入 Mac App Distribution 憑證。

- 自動下載並嵌入佈建描述檔。

- 重新簽章 `.app` 確保 App Store 相容。


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macOS CD 工作"] --> B["清理舊有鑰匙圈 (冪等性)"]
  B --> C["匯入 Mac Installer 憑證"]
  C --> D["匯入 Mac App Distribution 憑證"]
  D --> E["合併鑰匙圈搜尋列表"]
  E --> F["驗證 Mac 簽章身份"]
  F --> G["下載 Mac App Store 佈建描述檔"]
  G --> H["建置 macOS"]
  H --> I["嵌入佈建描述檔並簽章 .app"]
  I --> J["透過 Fastlane 部署 macOS 到 TestFlight"]
```

