### PR TITLE
fix(macos): Release 的 aps-environment 改為 production

### DIFF
--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -7,7 +7,7 @@
 		<string>Default</string>
 	</array>
 	<key>com.apple.developer.aps-environment</key>
-	<string>development</string>
+	<string>production</string>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>


### PR DESCRIPTION
### **User description**
## 摘要

macOS TestFlight 最新一次上傳被 altool 退回的訊息：

\`\`\`
[altool] Validation failed (409) Invalid code signing entitlements.
Your application bundle's signature contains code signing entitlements
that aren't supported on macOS. Specifically, the "development" value
for the com.apple.developer.aps-environment key in
".../Contents/MacOS/NKUST AP" isn't supported.
\`\`\`

## 修法

\`macos/Runner/Release.entitlements\`:

\`\`\`diff
  <key>com.apple.developer.aps-environment</key>
- <string>development</string>
+ <string>production</string>
\`\`\`

\`aps-environment = development\` 是給 Debug / Profile build 用的（連 Apple sandbox APNs、拿 sandbox token）。App Store 上架要求 Release build 填 \`production\`（連 production APNs）。

\`DebugProfile.entitlements\` / \`NKUST APDebug.entitlements\` 不動，本機開發與 debug push 測試不受影響。

## 進度

signing 鏈（Installer + App cert import、keychain search list、provisioning profile 下載、embed into .app、codesign with app-sandbox）在上次 CD run 都已經跑過了，altool 才能走到這一步檢查 entitlements。這應該是最後一道驗證錯誤。

## Test plan

- [ ] 下次 CD push → \`deploy_macos\` 走完到 upload_to_testflight 不再 code 409
- [ ] TestFlight 收到新 macOS build


___

### **PR Type**
Bug fix


___

### **Description**
- 修正 macOS TestFlight 上傳錯誤。

- 將 `aps-environment` 設定為 `production`。

- 解決 `altool` 驗證失敗問題。

- 確保 Release 版本正確簽名。


___

