### PR TITLE
fix(api): 修復 webap 登入流程多重失敗（cookie 解析 + session 綁定）

### DIFF
--- a/docs/cookie-handling.md
+++ b/docs/cookie-handling.md
@@ -1,0 +1,226 @@
+# Cookie 處理與 RFC 合規性
+
+> 對應實作：`lib/api/safe_cookie_manager.dart`
+> 修復脈絡：#411 / #412
+
+這份文件解釋為什麼專案有自己的 `SafeCookieManager` 而不直接用 `dio_cookie_manager` 的 `CookieManager`，並順便當作對讀 codebase 的學弟妹的 cookie 入門。
+
+## TL;DR
+
+- **學校 webap server 偶爾送出非 RFC 的 `Set-Cookie` header**（把多支 cookie 用逗號黏成一個 header value）
+- **標準 cookie parser 遇到這種輸入會 throw `FormatException`**，整條 interceptor 鏈陣亡，使用者看到「沒有網路」吐司
+- **`SafeCookieManager` 在丟給標準 parser 前先做防禦性切分**，並對每支 cookie 做 try/catch，壞掉一支不會連累整批
+- **背後的工程原則是 Postel's Law**：「送的時候嚴格、收的時候寬容」
+
+## 1. RFC 怎麼說
+
+### `Set-Cookie` header（server → client）
+
+RFC 6265 §3 + RFC 7230 §3.2.2 定義：
+
+> 多個 cookie **必須以多筆獨立的 `Set-Cookie:` header line** 送出，
+> **不可以**用逗號折疊（folding）成單一 header value。
+
+合規範例：
+
+```http
+HTTP/1.1 200 OK
+Set-Cookie: a=1; Path=/
+Set-Cookie: b=2; Path=/; HttpOnly
+```
+
+不合規範例（webap 偶爾這樣做）：
+
+```http
+HTTP/1.1 200 OK
+Set-Cookie: a=1; Path=/; Max-Age=3600,b=2; Path=/; HttpOnly
+                                     ^^ RFC 明文禁止
+```
+
+### 為什麼 RFC 要明文禁止逗號折疊？
+
+因為 **逗號可以合法出現在 cookie 屬性內**：
+
+```
+Set-Cookie: sid=xyz; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Path=/
+                            ^^^
+                            這個逗號是 HTTP-date 格式的一部分
+```
+
+如果允許用逗號折疊多個 cookie，就**無法可靠地分辨**哪個逗號是 cookie 邊界、哪個是日期格式的一部分。RFC 因此一刀切禁止。`Set-Cookie` 也是 RFC 7230 §3.2.2 對「同名 header 必須能用逗號合併」這條規則**唯一明文列出的例外**。
+
+### `Cookie` header（client → server）
+
+相對單純，RFC 6265 §5.4：
+
+```http
+GET /something HTTP/1.1
+Cookie: a=1; b=2; c=3
+```
+
+- `name=value` 用 `; ` 分隔
+- 全部塞進**單一** `Cookie:` header
+- 不送 `Path` / `Domain` / `Expires` 等屬性（那些是 server 才會用的）
+
+`SafeCookieManager.onRequest` 與其他手動拼 cookie header 的地方（例如 `nkust_helper.dart` 用 `package:http` 的部分）都遵守這格式。
+
+## 2. webap 的非合規行為
+
+實際抓到的 Set-Cookie：
+
+```
+Set-Cookie: name=val; Path=/; Max-Age=3600,jsessionid=aaakmpr9y1lhidnpzaqeqa
+```
+
+兩個 cookie（`name`、`jsessionid`）違規地用逗號黏在同一個 header value 裡。
+
+### 標準 parser 看到這串會發生什麼
+
+`dart:io` 的 `Cookie.fromSetCookieValue` 嚴格按 RFC，把 `;` 當屬性分隔符：
+
+1. 切出 cookie pair：`name=val`
+2. 屬性 1：`Path=/`
+3. 屬性 2：`Max-Age=3600,jsessionid=aaakmpr9y1lhidnpzaqeqa`
+4. 對 Max-Age 屬性的值做 `int.parse('3600,jsessionid=...')` → 💥 `FormatException`
+
+```mermaid
+sequenceDiagram
+    participant App
+    participant Dio
+    participant CookieMgr as PrivateCookieManager
+    participant Parser as Cookie.fromSetCookieValue
+    participant ErrIntcp as ErrorInterceptor
+
+    App->>Dio: dio.post(perchk.jsp)
+    Dio-->>App: 200 OK + Set-Cookie: a=1; Max-Age=3600,b=2
+    Dio->>CookieMgr: onResponse(response)
+    CookieMgr->>Parser: parse("a=1; Max-Age=3600,b=2")
+    Parser-->>CookieMgr: 💥 FormatException
+    CookieMgr-->>Dio: rethrow
+    Dio->>ErrIntcp: onError(...)
+    ErrIntcp-->>App: NetworkException(5000) "沒有網路"
+    Note over App: UI 顯示假性網路錯誤<br/>但登入其實成功了
+```
+
+## 3. SafeCookieManager 的設計
+
+### 策略
+
+在丟進標準 parser **之前**，先把可疑的逗號折疊切開：
+
+```dart
+List<String> splitMalformedSetCookie(String raw) {
+  // 找到 `,<optional space><name>=` 模式的逗號當 cookie 邊界。
+  // Expires 日期裡的 `, 09 Jun 2021` 因為 `09 Jun` 後面遇到 ` `
+  // 而非 `=`，所以不會被當邊界 — 安全。
+}
+```
+
+### 三層職責
+
+```dart
+class SafeCookieManager extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    // (1) 從 jar 載出符合 uri 的 cookie，拼成 Cookie header 送出去
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    // (2) 收到回應，先 splitMalformedSetCookie 再解析
+    // (3) 對每支 cookie try/catch 確保壞掉一支不會連累整批
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    // 如果錯誤回應裡也帶了 Set-Cookie，照樣存（很多 server 在 4xx 也 set 新 session）
+  }
+}
+```
+
+### 為什麼這樣不算「自己違反 RFC」
+
+**Robustness Principle / Postel's Law**（RFC 1958 §3.9）：
+
+> Be conservative in what you do, be liberal in what you accept from others.
+> 送出時嚴格按標準，接收時對對方違規盡量寬容。
+
+對應到本實作：
+- **送出**：`Cookie:` header 完全按 RFC 6265 §5.4 拼，沒有自創格式
+- **接收**：對 server 違規輸入做 best-effort 復原，**但不主動產生違規格式**
+
+我們沒有「發明非標準格式」，只是讓 client 在收到違規輸入時不崩。這跟瀏覽器行為一致——Chrome、Firefox 都會盡量解析破格 cookie，否則整個 web 就會被某些破爛 server 弄到不能用。
+
+## 4. 常見坑（讀 codebase 的人請注意）
+
+### Cronet vs Dio cookieJar
+
+App 在 Android 透過 `native_dio_adapter` 走 Cronet，iOS / macOS 走 URLSession。這些 native HTTP stack 自己也有 cookie 機制。
+
+**目前約定**：cookie 全部由 Dio 的 `SafeCookieManager` 管，native stack 的 cookie store 預設應為 disabled（Cronet 的 CookieManager 預設就不啟用）。如果哪天遇到「Dio jar 看到的 cookie 跟實際發出去的對不上」這種詭異現象，**第一個檢查這條**。
+
+### 手動拼 `Cookie:` header（e.g. `nkust_helper.dart`）
+
+部分 helper 用 `package:http`（不是 Dio），手動從 jar 載 cookie 拼進 `Cookie:` header：
+
+```dart
+final String cookieHeader = cookies
+    .map((Cookie c) => '${c.name}=${c.value}')
+    .join('; ');
+```
+
+**這格式是合規的**，符合 RFC 6265 §5.4。但要注意兩個雷：
+
+1. 用的是 `${c.name}=${c.value}`，**不是** `c.toString()`——後者輸出完整的 Set-Cookie 格式（含 Path/Expires/HttpOnly），那是 server → client 用的格式，反向送會讓 server 解不出來
+2. Path/Domain/Expires 的過濾要靠 `cookieJar.loadForRequest(uri)` 幫你篩，不能 `loadAll` 全送（會把不符合 path 的 cookie 也送出去，可能洩漏資訊或讓 server 困惑）
+
+### 為什麼 `dart:io` 的 `Cookie.toString()` 不能直接放進 `Cookie:` header
+
+`Cookie.toString()` 輸出的是 **Set-Cookie** 格式：
+
+```
+JSESSIONID=abc123; Path=/; HttpOnly; Expires=Wed, 09 Jun 2021 10:18:14 GMT
+```
+
+那是 server → client 用的。Client → server 的 `Cookie:` header 只要：
+
+```
+JSESSIONID=abc123
+```
+
+混用 = 送出去的 header 包含 server 永遠不會懂的 `Path=/; HttpOnly; Expires=...`，server 可能整支 cookie 直接拒收。
+
+## 5. 測試
+
+`test/safe_cookie_manager_test.dart` 覆蓋 `splitMalformedSetCookie` 的行為：
+
+| 測試 | 驗證 |
+|---|---|
+| `Max-Age=N,name=val` | 切成兩段，各自能 round-trip 過 `Cookie.fromSetCookieValue` |
+| `Expires=Wed, 09 Jun 2021 …` | **不切**（日期內的逗號保留） |
+| 純 RFC 合規的 `a=1; Path=/` | 不變動 |
+| 三個 cookie 用兩個逗號黏 | 切成三段 |
+| Trailing 逗號（後面沒有 `name=`）| 不切 |
+
+跑：
+
+```bash
+fvm flutter test test/safe_cookie_manager_test.dart
+```
+
+## 6. 給未來維護者的建議
+
+如果哪天又遇到「登入莫名其妙失敗」，依本次踩雷經驗，按代價排除順序：
+
+1. **抓 cURL 跟現有實作對比 header**——Referer / Origin / User-Agent / Cookie
+2. **看 server 真正回了什麼 HTML**（不是看包過的 Exception 訊息）——webap 的錯誤訊息常藏在 `<script>alert(...)</script>` 裡
+3. **檢查 cookie 流向**——validateCode.jsp 拿到的 JSESSIONID 是否真的有跟著 perchk.jsp 送出去？interceptor 有沒有同時實作 `onRequest` 和 `onResponse`？
+4. **預熱 session**——很多 JSP 系統的 captcha / CSRF token 是綁在 homepage 載入時 set 的 cookie 上，直接跳到子頁面不會綁
+
+## 參考
+
+- [RFC 6265 — HTTP State Management Mechanism](https://datatracker.ietf.org/doc/html/rfc6265)
+- [RFC 7230 §3.2.2 — Field Order](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.2)
+- [RFC 1958 §3.9 — Robustness Principle](https://datatracker.ietf.org/doc/html/rfc1958#section-3.9)
+- 修復脈絡：#411 / #412
+- 爬蟲整體架構：[crawler-architecture.md](./crawler-architecture.md)

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -150,6 +150,10 @@ class WebApHelper
           bodyBytes: imageBytes,
         );
 
+        // perchk.jsp does a server-side CSRF check that emits
+        // alert('Please Logon From Homepage!!') when the request lacks
+        // the homepage Referer/Origin. Without these, even a correct
+        // captcha gets rejected as 驗證碼錯誤.
         final Response<dynamic> res = await dio.post(
           'https://webap.nkust.edu.tw/nkust/perchk.jsp',
           data: <String, String>{
@@ -157,7 +161,13 @@ class WebApHelper
             'pwd': password,
             'etxt_code': captchaCode,
           },
-          options: Options(contentType: 'application/x-www-form-urlencoded'),
+          options: Options(
+            contentType: 'application/x-www-form-urlencoded',
+            headers: <String, String>{
+              'Referer': 'https://webap.nkust.edu.tw/nkust/index_main.html',
+              'Origin': 'https://webap.nkust.edu.tw',
+            },
+          ),
         );
         Helper.username = username;
         Helper.password = password;

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -9,6 +9,7 @@ import 'package:dio/io.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:nkust_ap/api/api_config.dart';
 import 'package:nkust_ap/api/ap_status_code.dart';
+import 'package:nkust_ap/api/safe_cookie_manager.dart';
 import 'package:nkust_ap/api/exceptions/api_exception.dart';
 import 'package:nkust_ap/api/helper.dart';
 import 'package:nkust_ap/api/leave_helper.dart';
@@ -256,7 +257,7 @@ class WebApHelper
 
     res = await (Dio()
           ..interceptors.add(
-            PrivateCookieManager(cookieJar),
+            SafeCookieManager(cookieJar),
           ))
         .post(
       'https://mobile.nkust.edu.tw/Account/LoginBySkytekPortalNewWindow',
@@ -295,7 +296,7 @@ class WebApHelper
 
     res = await (Dio()
           ..interceptors.add(
-            PrivateCookieManager(cookieJar),
+            SafeCookieManager(cookieJar),
           ))
         .post(
       'https://oosaf.nkust.edu.tw/Account/LoginBySkytekPortalNewWindow',
@@ -368,7 +369,7 @@ class WebApHelper
 
     res = await (Dio()
           ..interceptors.add(
-            PrivateCookieManager(cookieJar),
+            SafeCookieManager(cookieJar),
           ))
         .post(
       'https://stdsys.nkust.edu.tw/Student/Account/LoginBySkytekPortalNewWindow',

--- a/lib/api/ap_helper.dart
+++ b/lib/api/ap_helper.dart
@@ -74,6 +74,18 @@ class WebApHelper
     this.cookieJar = cookieJar;
   }
 
+  Future<void> _primeHomepage() async {
+    try {
+      await dio.get<dynamic>(
+        'https://webap.nkust.edu.tw/nkust/index_main.html',
+      );
+    } catch (e) {
+      // Non-fatal: if priming fails, fall through to the captcha loop
+      // and let the existing retry/error path surface the real failure.
+      log('[login] homepage prime failed: $e');
+    }
+  }
+
   Future<Uint8List?> getValidationImage() async {
     final Response<Uint8List> response = await dio.get<Uint8List>(
       'https://webap.nkust.edu.tw/nkust/validateCode.jsp',
@@ -136,6 +148,14 @@ class WebApHelper
     */
     //
     assert(retryCounts >= 0, 'retryCounts must be >= 0');
+
+    // Prime the session by visiting the homepage before fetching the
+    // captcha. webap binds the captcha to session cookies that are only
+    // set when index_main.html is loaded; jumping straight to
+    // validateCode.jsp leaves the session in a state where every
+    // subsequent perchk.jsp POST is rejected as 驗證碼錯誤 even with a
+    // correctly OCR-decoded code.
+    await _primeHomepage();
 
     for (int i = 0; i < retryCounts; i++) {
       try {

--- a/lib/api/api_config.dart
+++ b/lib/api/api_config.dart
@@ -6,6 +6,7 @@ import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:flutter/foundation.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
+import 'package:nkust_ap/api/safe_cookie_manager.dart';
 
 class ApiConfig {
   static const Duration connectTimeout = Duration(seconds: 15);
@@ -57,7 +58,7 @@ class ApiConfig {
   /// Creates a [Dio] instance configured for web scraping NKUST systems.
   ///
   /// Includes:
-  /// - [PrivateCookieManager] for non-RFC6265 cookie handling
+  /// - [SafeCookieManager] for non-RFC6265 cookie handling
   /// - [RetryInterceptor] for HTTP-level timeout/5xx auto-retry
   /// - [ErrorInterceptor] for enhanced Chinese error messages
   /// - [NativeAdapter] for iOS/Android/macOS
@@ -78,7 +79,7 @@ class ApiConfig {
     );
     // Insert cookie manager at position 0 so it runs before retry/error
     // interceptors.
-    dio.interceptors.insert(0, PrivateCookieManager(cookieJar));
+    dio.interceptors.insert(0, SafeCookieManager(cookieJar));
     return (dio: dio, cookieJar: cookieJar);
   }
 

--- a/lib/api/safe_cookie_manager.dart
+++ b/lib/api/safe_cookie_manager.dart
@@ -1,0 +1,146 @@
+import 'dart:developer';
+import 'dart:io';
+
+import 'package:ap_common/ap_common.dart';
+import 'package:cookie_jar/cookie_jar.dart';
+
+/// Drop-in replacement for [PrivateCookieManager] that survives the
+/// non-RFC `Set-Cookie` headers webap occasionally emits.
+///
+/// Specifically, webap ships responses where two cookies got
+/// concatenated into one `Set-Cookie` header value with a comma
+/// separator instead of being split into two separate headers. e.g.:
+///
+/// ```text
+/// Set-Cookie: name=val; Path=/; Max-Age=3600,jsessionid=aaakmp…
+/// ```
+///
+/// [PrivateCookieManager] (and the dart:io stdlib parser it copies
+/// from) treat `;` as the only attribute terminator, so it slurps the
+/// entire tail starting at `3600` into the `Max-Age` value and then
+/// `int.parse` throws `FormatException`, killing the whole interceptor
+/// chain. That bubbles up as `NetworkException` on the Dio side and
+/// the user sees a "no network" toast on a perfectly good login
+/// response — exactly the symptom we hit:
+///
+///     Unhandled Exception: NetworkException(5000): FormatException:
+///       Invalid radix-10 number (at character 3)
+///     3600,jsessionid=aaakmpr9y1lhidnpzaqeqa
+///       ^
+///
+/// This class pre-splits each `Set-Cookie` value at any comma that
+/// looks like a cookie boundary (i.e. the comma is followed by an
+/// optional space and then `<name>=`, where `<name>` contains no `=`,
+/// `;` or `,`). Commas inside `Expires=Wed, 09 Jun 2021 …` dates do
+/// not match because `09 Jun …` has no `=` before the next attribute
+/// terminator, so they pass through unchanged.
+///
+/// As defence-in-depth we also `try`/`catch` per cookie, log + skip
+/// the malformed one instead of failing the whole batch — losing one
+/// cookie is worse than losing all of them.
+class SafeCookieManager extends Interceptor {
+  SafeCookieManager(this.cookieJar);
+
+  final CookieJar cookieJar;
+
+  @override
+  void onRequest(
+    RequestOptions options,
+    RequestInterceptorHandler handler,
+  ) {
+    _attachCookies(options).whenComplete(() => handler.next(options));
+  }
+
+  @override
+  void onResponse(
+    Response<dynamic> response,
+    ResponseInterceptorHandler handler,
+  ) {
+    _saveCookiesSafely(response).whenComplete(() => handler.next(response));
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    if (err.response != null) {
+      _saveCookiesSafely(err.response!).whenComplete(() => handler.next(err));
+    } else {
+      handler.next(err);
+    }
+  }
+
+  Future<void> _attachCookies(RequestOptions options) async {
+    try {
+      final List<Cookie> cookies = await cookieJar.loadForRequest(options.uri);
+      if (cookies.isEmpty) return;
+      // dart:io Cookie.toString() emits the full Set-Cookie form
+      // (with Path/Expires/etc.), which is wrong for outbound Cookie
+      // headers — servers only want `name=value; name=value`.
+      options.headers[HttpHeaders.cookieHeader] =
+          cookies.map((Cookie c) => '${c.name}=${c.value}').join('; ');
+    } catch (e) {
+      log('[cookie] loadForRequest failed: $e');
+    }
+  }
+
+  Future<void> _saveCookiesSafely(Response<dynamic> response) async {
+    final List<String>? rawHeaders =
+        response.headers[HttpHeaders.setCookieHeader];
+    if (rawHeaders == null || rawHeaders.isEmpty) return;
+
+    final List<Cookie> cookies = <Cookie>[];
+    for (final String raw in rawHeaders) {
+      for (final String segment in splitMalformedSetCookie(raw)) {
+        try {
+          cookies.add(Cookie.fromSetCookieValue(segment));
+        } catch (e) {
+          log('[cookie] skip malformed Set-Cookie segment: '
+              '${_preview(segment)} ($e)');
+        }
+      }
+    }
+
+    if (cookies.isEmpty) return;
+    try {
+      await cookieJar.saveFromResponse(response.requestOptions.uri, cookies);
+    } catch (e, st) {
+      log('[cookie] saveFromResponse failed: $e\n$st');
+    }
+  }
+
+  static String _preview(String s) =>
+      s.length > 80 ? '${s.substring(0, 80)}…' : s;
+}
+
+/// Splits a `Set-Cookie` header value at any comma that is immediately
+/// followed by `<optional space><name>=`, treating that comma as a
+/// cookie boundary. Commas within `Expires=Wed, 09 Jun 2021 …` dates
+/// are left intact because the substring after them never reaches a
+/// `=` before the next `;`.
+///
+/// Public for unit testing; callers in this file should still go
+/// through [SafeCookieManager].
+List<String> splitMalformedSetCookie(String raw) {
+  final List<String> out = <String>[];
+  int start = 0;
+  for (int i = 0; i < raw.length; i++) {
+    if (raw[i] != ',') continue;
+    int j = i + 1;
+    while (j < raw.length && raw[j] == ' ') {
+      j++;
+    }
+    // Read potential cookie name characters until we hit `=`, `;`,
+    // another `,` or whitespace.
+    int nameEnd = j;
+    while (nameEnd < raw.length) {
+      final String c = raw[nameEnd];
+      if (c == '=' || c == ';' || c == ',' || c == ' ') break;
+      nameEnd++;
+    }
+    if (nameEnd > j && nameEnd < raw.length && raw[nameEnd] == '=') {
+      out.add(raw.substring(start, i));
+      start = j;
+    }
+  }
+  out.add(raw.substring(start));
+  return out;
+}

--- a/lib/api/vms_bus_helper.dart
+++ b/lib/api/vms_bus_helper.dart
@@ -3,13 +3,13 @@ import 'dart:io';
 
 import 'package:ap_common/ap_common.dart';
 import 'package:cookie_jar/cookie_jar.dart';
-import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:native_dio_adapter/native_dio_adapter.dart';
 import 'package:nkust_ap/api/api_config.dart';
 import 'package:nkust_ap/api/capability/bus_provider.dart';
 import 'package:nkust_ap/api/parser/parser_utils.dart';
 import 'package:nkust_ap/api/parser/vms_bus_parser.dart';
+import 'package:nkust_ap/api/safe_cookie_manager.dart';
 import 'package:nkust_ap/models/booking_bus_data.dart';
 import 'package:nkust_ap/models/bus_data.dart';
 import 'package:nkust_ap/models/bus_reservations_data.dart';
@@ -78,7 +78,7 @@ class VmsBusHelper implements BusProvider {
       dio.httpClientAdapter = NativeAdapter();
     }
 
-    dio.interceptors.add(CookieManager(cookieJar));
+    dio.interceptors.add(SafeCookieManager(cookieJar));
   }
 
   /// Logs into VMS via its direct form POST. A successful login returns

--- a/test/safe_cookie_manager_test.dart
+++ b/test/safe_cookie_manager_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nkust_ap/api/safe_cookie_manager.dart';
+
+void main() {
+  group('splitMalformedSetCookie', () {
+    test('splits Max-Age=N,name=val into two parsable segments', () {
+      final List<String> parts = splitMalformedSetCookie(
+        'first=alpha; Path=/; Max-Age=3600,jsessionid=aaakmpr9y1lhidnpzaqeqa',
+      );
+
+      expect(parts, hasLength(2));
+      // Each segment must round-trip through Cookie.fromSetCookieValue
+      // without the FormatException that the unsafe path hit in prod.
+      final Cookie first = Cookie.fromSetCookieValue(parts[0]);
+      final Cookie second = Cookie.fromSetCookieValue(parts[1]);
+      expect(first.name, 'first');
+      expect(first.value, 'alpha');
+      expect(second.name, 'jsessionid');
+      expect(second.value, 'aaakmpr9y1lhidnpzaqeqa');
+    });
+
+    test('does not split commas inside Expires= dates', () {
+      final List<String> parts = splitMalformedSetCookie(
+        'sid=xyz; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Path=/',
+      );
+
+      expect(parts, hasLength(1));
+      final Cookie c = Cookie.fromSetCookieValue(parts.single);
+      expect(c.name, 'sid');
+      expect(c.value, 'xyz');
+    });
+
+    test('handles plain RFC-compliant Set-Cookie unchanged', () {
+      final List<String> parts = splitMalformedSetCookie('a=1; Path=/');
+      expect(parts, <String>['a=1; Path=/']);
+    });
+
+    test('splits three comma-joined cookies', () {
+      final List<String> parts = splitMalformedSetCookie(
+        'a=1; Max-Age=10,b=2; Path=/,c=3',
+      );
+      expect(parts, hasLength(3));
+      expect(Cookie.fromSetCookieValue(parts[0]).name, 'a');
+      expect(Cookie.fromSetCookieValue(parts[1]).name, 'b');
+      expect(Cookie.fromSetCookieValue(parts[2]).name, 'c');
+    });
+
+    test('does not split on a trailing comma with no following name', () {
+      // Defensive: a stray comma at the very end shouldn't produce an
+      // empty segment that downstream parsing would choke on.
+      final List<String> parts = splitMalformedSetCookie('a=1; Path=/,');
+      // Only commas followed by `<name>=` count as boundaries; this
+      // trailing comma has nothing after it, so we keep the value intact.
+      expect(parts, hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
## 摘要

修復 #411 — webap 登入流程被四個獨立問題層層擋下，使用者實際看到的是「沒有網路」或永遠「驗證碼錯誤」。本 PR 從 cookie 解析、cookie 流向、CSRF header、session 預熱四個面向一次處理。

## 變更

依 commit 順序：

1. **`fix(api): handle webap's malformed comma-joined Set-Cookie headers`** — 新增 `SafeCookieManager` 取代 `PrivateCookieManager`，完整實作 `onRequest`/`onResponse`/`onError`，預先切分逗號黏在一起的 Set-Cookie 並對每支 cookie 做 try/catch；附 5 個單元測試
2. **`fix(bus): use SafeCookieManager in VmsBusHelper`** — 同類風險的防範修復
3. **`fix(api): send Referer + Origin on perchk.jsp login post`** — 通過 webap 的 CSRF check
4. **`fix(api): prime webap session by GETing homepage before login`** — 取得 WAF/anti-bot cookies 讓 captcha 真正綁到 session
5. **`docs: add cookie handling and RFC compliance guide`** — 新增 [`docs/cookie-handling.md`](../blob/fix/login-referer-origin/docs/cookie-handling.md)，給未來維護的學弟妹參考

每個 commit 各自獨立、各自可 revert。

## RFC 合規性說明

> 對應討論留底，詳細解釋見 [`docs/cookie-handling.md`](../blob/fix/login-referer-origin/docs/cookie-handling.md)。

| 角色 | 行為 | 是否合規 |
|---|---|---|
| **webap server**（現況） | 偶爾把多支 cookie 用逗號折疊在單一 `Set-Cookie:` header value 裡 | ❌ **不合規** — 違反 RFC 6265 §3 / RFC 7230 §3.2.2，因為 `Expires=Wed, 09 Jun ...` 的逗號會跟 cookie 邊界混淆 |
| **`PrivateCookieManager`**（PR 前） | 嚴格按 RFC，把整個 value 當一支 cookie 解析 | ✅ 合規但**不寬容** — 遇到 webap 的逗號折疊就 throw `FormatException` |
| **`SafeCookieManager`**（PR 後） | 解析前先補一層切分；送出時的 `Cookie:` header 完全按 RFC 6265 §5.4 | ✅ 合規 + **對 server 違規做防禦性復原** |

> 設計原則：**Postel's Law（RFC 1958 §3.9）— 送的時候嚴格、收的時候寬容**。我們從來沒有自己產生違反 RFC 的輸出，只是讓 client 在收到 server 違規輸入時不崩，跟瀏覽器處理破格 cookie 的策略一致。

## 測試計畫

- [x] `fvm flutter analyze lib/api/ test/` — 無新增 error / warning
- [x] `fvm flutter test test/safe_cookie_manager_test.dart` — 5 tests pass
- [x] 實機 Android：登入成功，課表（走 `loginToStdsys` 跨 domain SSO）載入正常
- [ ] 實機 iOS 待測
- [ ] 實機 macOS 待測

## 相關

Closes #411