### PR TITLE
fix(ci): bump VERSION_CODE at prepare to avoid duplicates on partial failure

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,11 +44,16 @@ jobs:
         run: |
           VERSION=$(grep '^version: ' pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-      - name: Get version code from variable
+      - name: Get version code and bump VERSION_CODE for next run
         id: get_version_code
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-          echo "version_code=${{ vars.VERSION_CODE }}" >> $GITHUB_OUTPUT
-          echo "Using version code: ${{ vars.VERSION_CODE }}"
+          CURRENT="${{ vars.VERSION_CODE }}"
+          NEXT=$((CURRENT + 1))
+          echo "version_code=$CURRENT" >> $GITHUB_OUTPUT
+          gh variable set VERSION_CODE --body "$NEXT" --repo "${{ github.repository }}"
+          echo "Using version code: $CURRENT (VERSION_CODE bumped to $NEXT for next run)"
       - name: Aggregate changelog from merged PRs
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -441,18 +446,3 @@ jobs:
             nkust_ap_windows_portable.zip
             nkust_ap_linux.tar.gz
             nkust_ap_linux.snap
-
-  finalize:
-    name: Increment Version Code
-    needs: [prepare, deploy_android, deploy_ios, deploy_macos, deploy_windows, deploy_linux, github_release]
-    if: always() && needs.github_release.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Increment VERSION_CODE
-        env:
-          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
-        run: |
-          CURRENT=${{ needs.prepare.outputs.version_code }}
-          NEXT=$((CURRENT + 1))
-          gh variable set VERSION_CODE --body "$NEXT" --repo "${{ github.repository }}"
-          echo "Version code incremented: $CURRENT -> $NEXT"


### PR DESCRIPTION
### **User description**
## Summary

- Move VERSION_CODE bump from the trailing `finalize` job into the `prepare` job, immediately after reading the value
- Drop the `finalize` job entirely

## Why

The previous design only bumped `VERSION_CODE` if `github_release` succeeded, and `github_release` itself fails when any platform's artifact is missing (e.g. Windows build fails → no `windows-installer-artifact` → release creation fails → finalize skipped). The next workflow run then reuses the same version code, which clashes with whatever already uploaded successfully (Play Store / TestFlight reject duplicate build numbers).

By bumping at the start, every workflow run gets a unique version code regardless of which platforms succeed or fail. The trade-off is that a fully-failed run "burns" a number, leaving a gap in the sequence — which is harmless because stores only require monotonically increasing build numbers.

## Test plan

- [ ] Trigger CD on develop, confirm `vars.VERSION_CODE` advances by 1 immediately after `prepare`
- [ ] Verify all platform builds (`--build-number=...`) still receive the pre-bump value
- [ ] Simulate a platform failure (or rely on existing `continue-on-error` paths) and confirm the next run no longer duplicates the version code


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- 在 `prepare` 任務中提前遞增 `VERSION_CODE`。

- 解決部分部署失敗導致版本號重複問題。

- 移除冗餘的 `finalize` 任務。


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph 舊流程
        A_old[prepare 任務] --> B_old[部署]
        B_old -- 成功時 --> C_old[finalize 任務]
        C_old --> D_old[遞增 VERSION_CODE]
    end

    subgraph 新流程
        A_new[prepare 任務] --> B_new[立即遞增 VERSION_CODE]
        B_new --> C_new[部署]
    end
```

