### PR TITLE
chore: release v4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter application.
 
 publish_to: none
 
-version: 3.13.0
+version: 4.0.0
 
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
### **User description**
## Summary

- Bump app version from `3.13.0` → `4.0.0` in `pubspec.yaml`.
- Major version bump to mark the i18n migration to slang (#415, closes #368) as the v4 baseline.
- No build number in `pubspec.yaml`; Android `versionCode` is managed by CI (`fix(ci): bump VERSION_CODE at prepare ...`, #413).

## Test plan

- [x] `pubspec.yaml` only — single-line change
- [ ] CI green


___

### **PR Type**
Enhancement, Other


___

### **Description**
- 應用程式版本更新至 `4.0.0`。

- 標誌著國際化全面遷移至 `slang`。

- 建立應用程式的新基準版本。


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["舊版本 (v3.13.0)"] --> B["完成 i18n Slang 遷移"]
    B --> C["發布新版本 (v4.0.0)"]
```

