### PR TITLE
fix(stdsys): 修復課表與個人學籍爬蟲

### DIFF
--- a/lib/api/parser/stdsys_parser.dart
+++ b/lib/api/parser/stdsys_parser.dart
@@ -403,42 +403,36 @@ class StdsysParser {
   static UserInfo userInfoParser(dynamic rawHtml) {
     final Document document = parse(rawHtml);
 
-    final List<Element> divs = document.querySelectorAll('div.col-6');
-
     String? name;
     String? educationSystem;
     String? department;
     String? className;
     String? id;
 
-    for (final Element div in divs) {
-      final String? label = div.querySelector('label')?.text.trim();
-      final String? value = div.querySelector('.fielddata')?.text.trim();
+    for (final Element item in document.querySelectorAll('.info-item')) {
+      final String label =
+          item.querySelector('.info-label')?.text.trim() ?? '';
+      final String value =
+          item.querySelector('.info-value')?.text.trim() ?? '';
 
-      if (label == null) continue;
-
-      if (label.contains('姓　　名')) {
-        name = value;
-      } else if (label.contains('學　　制')) {
-        educationSystem = value;
-      } else if (label.contains('科　　系')) {
-        department = value;
-      } else if (label.contains('班　　級')) {
-        className = value;
-      } else if (label.contains('學　　號')) {
-        id = value;
+      switch (label) {
+        case '姓名':
+          name = value;
+        case '學制':
+          educationSystem = value;
+        case '科系':
+          department = value;
+        case '班級':
+          className = value;
+        case '學號':
+          id = value;
       }
     }
 
-    final Element? img = document.querySelector('img.photo');
-    String? pictureUrl;
-
-    if (img != null) {
-      final String? src = img.attributes['src'];
-      if (src != null) {
-        pictureUrl = 'https://stdsys.nkust.edu.tw$src';
-      }
-    }
+    final Element? img = document.querySelector('img.student-photo');
+    final String? src = img?.attributes['src'];
+    final String? pictureUrl =
+        src == null ? null : 'https://stdsys.nkust.edu.tw$src';
 
     return UserInfo(
       name: name ?? '',

--- a/lib/api/stdsys_helper.dart
+++ b/lib/api/stdsys_helper.dart
@@ -144,11 +144,22 @@ class StdsysHelper
   }) async {
     await _webApHelper.loginToStdsys();
 
+    // 先 GET 表單頁，讓 server 種下 .AspNetCore.Antiforgery.* 與 XSRF-TOKEN
+    // cookie，後續 POST 才有 antiforgery token 可帶。
+    await dio.get<String>(
+      'https://stdsys.nkust.edu.tw/student/Course/StudentCourseList',
+      options: Options(responseType: ResponseType.plain),
+    );
+
     final List<Cookie> cookies = await cookieJar
         .loadForRequest(Uri.parse('https://stdsys.nkust.edu.tw'));
     final String cookieHeader = cookies
         .map((Cookie cookie) => '${cookie.name}=${cookie.value}')
         .join('; ');
+    final String? xsrfToken = cookies
+        .where((Cookie cookie) => cookie.name == 'XSRF-TOKEN')
+        .map((Cookie cookie) => cookie.value)
+        .firstOrNull;
 
     // schoolYearSms 格式：學年-學期，例如 "114-2"
     final String schoolYearSms = '$year-$semester';
@@ -161,8 +172,12 @@ class StdsysHelper
           responseType: ResponseType.plain,
           contentType: 'application/x-www-form-urlencoded',
           headers: <String, dynamic>{
+            'Accept': '*/*',
+            'Origin': 'https://stdsys.nkust.edu.tw',
             'Referer':
                 'https://stdsys.nkust.edu.tw/student/Course/StudentCourseList',
+            'X-Requested-With': 'XMLHttpRequest',
+            if (xsrfToken != null) 'X-XSRF-TOKEN': xsrfToken,
             'Cookie': cookieHeader,
           },
         ),


### PR DESCRIPTION
## 摘要
- `getCourseTable`：先 GET `/student/Course/StudentCourseList` 讓伺服器種下 `.AspNetCore.Antiforgery.*` / `XSRF-TOKEN` cookie，POST 時補上 `X-XSRF-TOKEN`、`X-Requested-With`、`Origin`、`Accept` header，避免 antiforgery 驗證失敗。
- `userInfoParser`：配合 stdsys 改版後的 DOM 調整。新版改用 `.info-item` / `.info-label` / `.info-value`、label 文字移除全形空白、學生照片 class 由 `img.photo` 改為 `img.student-photo`。

## 測試項目
- [ ] 登入 stdsys 後呼叫 `getCourseTable`，確認 114-2 等學期能正常取得課表，且空課表學期仍走 `CourseData.empty()`。
- [ ] 呼叫 `getUserInfo`，確認姓名 / 學制 / 科系 / 班級 / 學號 / 個人照片 URL 都有值。
- [ ] 既有的 `roomList` / `roomCourseTableQuery` 不受影響。