### PR TITLE
chore: release v4.0.1

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,6 +1,6 @@
 {
   "40044": {
-    "version": "4.0.0",
+    "version": "4.0.1",
     "date": "2026-05-02",
     "zh-TW": [
       "全新 Material Design 3 介面：採用 Material You 設計語言，帶來更現代的視覺風格與動態色彩體驗。"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter application.
 
 publish_to: none
 
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
### **User description**
## 摘要

升版 \`4.0.0\` → \`4.0.1\`，並把 \`changelog.json\` 中 \`40044\` entry 的 \`version\` 欄位由 \`4.0.0\` 同步成 \`4.0.1\`。內容（Material Design 3 介面）不變。

\`pubspec.yaml\` 不帶 build number——versionCode 仍由 CI 的 \`vars.VERSION_CODE\` 在 CD prepare job 管理（沿用 #413 的設計）。

## 測試項目

- [ ] CI 全綠（Analyze & Test、各平台 build）
- [ ] CD prepare job 拿到 \`VERSION_CODE = 40044\`，並在 generate_changelog 時對 \`changelog_aggregated.json\` 走 LLM aggregator 路徑
- [ ] 升上 build 40044 後，app 內「剛升版」對話框顯示 v4.0.1 的 Material Design 3 文案


___

### **PR Type**
Enhancement


___

### **Description**
- 將應用程式版本從 `4.0.0` 更新至 `4.0.1`。

- 同步 `changelog.json` 中 `40044` 的版本號。

- 更新 `pubspec.yaml` 中的應用程式版本。


___

