### PR TITLE
修復：live test 接受任何 TLS 憑證（不再依賴 bundled cert）

### DIFF
--- a/packages/nkust_crawler/test/live/_helpers.dart
+++ b/packages/nkust_crawler/test/live/_helpers.dart
@@ -82,33 +82,38 @@ String redact(String? value) {
   return '${value[0]}${"•" * (value.length - 2)}${value[value.length - 1]}';
 }
 
-/// Adds the NKUST in-house TWCA root certificate to
-/// `SecurityContext.defaultContext` so that HTTPS handshakes against
-/// `acad.nkust.edu.tw` (and any other host signed by the same chain)
-/// don't fail with `CERTIFICATE_VERIFY_FAILED` on CI / desktop runners
-/// that ship with the upstream Mozilla CA bundle only.
+/// Disables TLS certificate verification for the entire test process.
 ///
-/// The Flutter app does this from `main.dart` via `PlatformAssetBundle`;
-/// from inside `dart test` we read the same `.cer` file straight off
-/// disk. No-op if the cert can't be located (so the test still tries to
-/// connect and produces a useful error message if the host has actually
-/// changed its certificate).
-void trustNkustCa() {
-  for (final String candidate in <String>[
-    'assets/ca/twca_nkust.cer',
-    '../../assets/ca/twca_nkust.cer',
-  ]) {
-    final File file = File(candidate);
-    if (file.existsSync()) {
-      SecurityContext.defaultContext.setTrustedCertificatesBytes(
-        file.readAsBytesSync(),
-      );
-      return;
-    }
+/// NKUST hosts (notably `acad.nkust.edu.tw`) are signed by TWCA, which
+/// the CI Ubuntu runner's default Mozilla CA bundle does not trust. We
+/// previously shipped a bundled `assets/ca/twca_nkust.cer` and added it
+/// to `SecurityContext.defaultContext`, but the school's certs rotate
+/// on their own schedule (~annually) and there is no stable feed for
+/// the new chain, so the bundled cert silently goes stale and tests
+/// start failing weeks later for the same reason.
+///
+/// For *live tests against the school* the pragmatic answer is to
+/// accept any certificate the server presents — we're not validating
+/// MITM resistance here, we're validating that endpoints respond and
+/// that parsers still understand the response. Production app code is
+/// NOT affected (this only runs inside `dart test`, never wired from
+/// `main.dart`).
+///
+/// Works by installing an [HttpOverrides] that flips
+/// `badCertificateCallback` on every [HttpClient] the test process
+/// constructs — which covers Dio's default `IOHttpClientAdapter` as
+/// well as raw `dart:io` HttpClient usage.
+void acceptAnyTlsCertificate() {
+  HttpOverrides.global = _AcceptAnyCertHttpOverrides();
+}
+
+class _AcceptAnyCertHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return super.createHttpClient(context)
+      ..badCertificateCallback = (X509Certificate _, String __, int ___) =>
+          true;
   }
-  // ignore: avoid_print
-  print('[live] WARNING: assets/ca/twca_nkust.cer not found relative to '
-      '${Directory.current.path}; acad.nkust.edu.tw handshake will fail.');
 }
 
 /// Locates `assets/eucdist/` regardless of whether the test is run from

--- a/packages/nkust_crawler/test/live/_helpers.dart
+++ b/packages/nkust_crawler/test/live/_helpers.dart
@@ -82,6 +82,35 @@ String redact(String? value) {
   return '${value[0]}${"•" * (value.length - 2)}${value[value.length - 1]}';
 }
 
+/// Adds the NKUST in-house TWCA root certificate to
+/// `SecurityContext.defaultContext` so that HTTPS handshakes against
+/// `acad.nkust.edu.tw` (and any other host signed by the same chain)
+/// don't fail with `CERTIFICATE_VERIFY_FAILED` on CI / desktop runners
+/// that ship with the upstream Mozilla CA bundle only.
+///
+/// The Flutter app does this from `main.dart` via `PlatformAssetBundle`;
+/// from inside `dart test` we read the same `.cer` file straight off
+/// disk. No-op if the cert can't be located (so the test still tries to
+/// connect and produces a useful error message if the host has actually
+/// changed its certificate).
+void trustNkustCa() {
+  for (final String candidate in <String>[
+    'assets/ca/twca_nkust.cer',
+    '../../assets/ca/twca_nkust.cer',
+  ]) {
+    final File file = File(candidate);
+    if (file.existsSync()) {
+      SecurityContext.defaultContext.setTrustedCertificatesBytes(
+        file.readAsBytesSync(),
+      );
+      return;
+    }
+  }
+  // ignore: avoid_print
+  print('[live] WARNING: assets/ca/twca_nkust.cer not found relative to '
+      '${Directory.current.path}; acad.nkust.edu.tw handshake will fail.');
+}
+
 /// Locates `assets/eucdist/` regardless of whether the test is run from
 /// the repo root or from `packages/nkust_crawler/`.
 Directory findTemplateDir() {

--- a/packages/nkust_crawler/test/live/authenticated_live_test.dart
+++ b/packages/nkust_crawler/test/live/authenticated_live_test.dart
@@ -35,6 +35,9 @@ void main() {
       return;
     }
 
+    print('[live] trusting NKUST TWCA root certificate');
+    trustNkustCa();
+
     print('[live] configuring in-memory storage');
     configureCrawlerStorage(InMemoryKeyValueStore());
 

--- a/packages/nkust_crawler/test/live/authenticated_live_test.dart
+++ b/packages/nkust_crawler/test/live/authenticated_live_test.dart
@@ -35,8 +35,8 @@ void main() {
       return;
     }
 
-    print('[live] trusting NKUST TWCA root certificate');
-    trustNkustCa();
+    print('[live] accepting any TLS cert (test process only)');
+    acceptAnyTlsCertificate();
 
     print('[live] configuring in-memory storage');
     configureCrawlerStorage(InMemoryKeyValueStore());

--- a/packages/nkust_crawler/test/live/health_check_live_test.dart
+++ b/packages/nkust_crawler/test/live/health_check_live_test.dart
@@ -5,6 +5,8 @@ library;
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
+import '_helpers.dart';
+
 /// Liveness probes for every NKUST endpoint we depend on. No
 /// authentication, no parsing — just a plain GET that asserts the server
 /// answered below 500. If any of these fail, the school is having an
@@ -15,6 +17,8 @@ import 'package:test/test.dart';
 /// can classify failures (server-down vs parser-drift) by grepping the
 /// reporter output.
 void main() {
+  setUpAll(trustNkustCa);
+
   final Dio healthDio = Dio(
     BaseOptions(
       connectTimeout: const Duration(seconds: 10),

--- a/packages/nkust_crawler/test/live/health_check_live_test.dart
+++ b/packages/nkust_crawler/test/live/health_check_live_test.dart
@@ -17,7 +17,7 @@ import '_helpers.dart';
 /// can classify failures (server-down vs parser-drift) by grepping the
 /// reporter output.
 void main() {
-  setUpAll(trustNkustCa);
+  setUpAll(acceptAnyTlsCertificate);
 
   final Dio healthDio = Dio(
     BaseOptions(

--- a/packages/nkust_crawler/test/live/notifications_live_test.dart
+++ b/packages/nkust_crawler/test/live/notifications_live_test.dart
@@ -13,8 +13,8 @@ import '_helpers.dart';
 /// HTML extractor still match the live server.
 void main() {
   setUpAll(() {
-    print('[live] trusting NKUST TWCA root certificate');
-    trustNkustCa();
+    print('[live] accepting any TLS cert (test process only)');
+    acceptAnyTlsCertificate();
     print('[live] configuring in-memory storage');
     configureCrawlerStorage(InMemoryKeyValueStore());
   });

--- a/packages/nkust_crawler/test/live/notifications_live_test.dart
+++ b/packages/nkust_crawler/test/live/notifications_live_test.dart
@@ -13,6 +13,8 @@ import '_helpers.dart';
 /// HTML extractor still match the live server.
 void main() {
   setUpAll(() {
+    print('[live] trusting NKUST TWCA root certificate');
+    trustNkustCa();
     print('[live] configuring in-memory storage');
     configureCrawlerStorage(InMemoryKeyValueStore());
   });


### PR DESCRIPTION
## 摘要

每日 `Crawler Monitor` workflow merge 進 master 之後**天天 fail**。根因：

- `acad.nkust.edu.tw` 用的是 TWCA 憑證鏈
- CI Ubuntu runner 預設只有 Mozilla CA bundle，沒有 TWCA root
- `dart test` SSL handshake → `CERTIFICATE_VERIFY_FAILED`

## 為什麼地端看不到

macOS dev 機 system keychain 已經有 TWCA root → 本地 `dart test -P live-anonymous` 不會炸。Ubuntu CI 才會。

## 為什麼不 bundle cert

最初想法是把 `assets/ca/twca_nkust.cer` load 進 `SecurityContext.defaultContext`（跟 `main.dart` 一樣）。但學校 cert chain 大約一年輪換一次，沒有穩定的 feed 可以自動更新，**bundle 的 .cer 早晚會過期** → tests 又會 silent fail 幾個禮拜後才被發現。同樣的問題會循環。

## 改用「test 環境接受任意 cert」

```dart
class _AcceptAnyCertHttpOverrides extends HttpOverrides {
  @override
  HttpClient createHttpClient(SecurityContext? context) {
    return super.createHttpClient(context)
      ..badCertificateCallback = (_, __, ___) => true;
  }
}

void acceptAnyTlsCertificate() {
  HttpOverrides.global = _AcceptAnyCertHttpOverrides();
}
```

三個 live test 的 `setUpAll` 都呼叫一次。

**Production app code 不受影響** — 這只在 `dart test` process 裡生效，永遠不會從 `main.dart` 接進來。Live test 的目的是「endpoint 還活著 + parser 還對得上 response」，不是驗證 MITM 抵抗力 — cert 嚴格驗證對這層測試沒有附加價值。

## 驗證

```
00:00 +7: All tests passed!
```

七個 endpoint（含 acad）在 Ubuntu 風格的乾淨 dart test 環境裡全部 pass。

## 測試計畫

- [ ] merge 後等一輪 daily `Crawler Monitor`（TPE 02:41 schedule）
- [ ] 確認 status: success
- [ ] 確認下次學校換 cert 時這個 PR 不需要再動

## Trade-off

| 方案 | 優點 | 缺點 |
|---|---|---|
| Bundle `.cer` | 嚴格驗證 cert chain | cert 過期就 silent fail，要手動更新 |
| **本 PR：接受任意 cert（test only）** | 不會因 cert 輪換 break，永久穩定 | test 不再驗證 cert chain（live test 本來也不該驗）|
| 完全跳過 SSL 驗證在 production | — | ❌ 絕對不行 |

選方案 2。