### PR TITLE
chore(ci): 加入 Dependabot 設定（pub / bundler）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "20:00"
+      timezone: "Asia/Taipei"
+    versioning-strategy: increase
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # ap_common 系列互相以 pinned dev 版本互指，
+      # 拆開單獨升版會 version solving failed，必須綁成同一支 PR
+      ap-common:
+        patterns:
+          - "ap_common"
+          - "ap_common_*"
+      dart-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "bundler"
+    directory: "/android"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "bundler"
+    directory: "/ios"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
### **User description**
## 變更摘要

新增 `.github/dependabot.yml`，讓 Dependabot 自動追蹤 pub 與 bundler 依賴並開 PR。此 repo 先前沒有任何 Dependabot 設定檔，過去的 bundler PR 都是 GitHub 預設的 security updates 產生的。

## 變更內容

- 新增 pub ecosystem：每週一 20:00（Asia/Taipei）檢查
  - `versioning-strategy: increase`，直接 bump constraint（pubspec 已有 `publish_to: none`，Dependabot 本來就會判定為 app，這裡明寫避免之後誤判成 widen）
  - group `ap-common`：`ap_common` / `ap_common_firebase` / `ap_common_plugin` 綁成同一支 PR。這幾個 package 互相以 pinned dev 版本互指，拆開單獨升版會 version solving failed，PR 根本開不出來
  - group `dart-minor-patch`：minor / patch 合併成一支 PR，major 維持各自獨立
  - `open-pull-requests-limit: 5`，避免首次啟用時一次湧入大量 PR
- 新增 bundler ecosystem（`/android`、`/ios`）：每月檢查，limit 3

## 測試方式

- 此 PR 只動 `.github/dependabot.yml`，不在 `ci.yml` 的 paths filter 內，因此不會觸發 CI build
- merge 後可在 Insights → Dependency graph → Dependabot 查看 pub job 的執行記錄，確認 `dependency_services` 正常解析（Dependabot 會依 pubspec 的 sdk constraint 自動 checkout 對應的 Flutter SDK）

## 影響範圍與風險

- 不影響 app 程式碼與 build 流程
- 目前此 repo 的 Dependabot 處於 **paused** 狀態（因為 PR #247 `rexml` 從 2024-05 掛到現在未處理，超過 90 天無互動）。修改 `dependabot.yml` 本身即可解除暫停，merge 後就會開始運作
- 首次啟用會有一批既有落後套件的 PR，已用 group 與 limit 控制數量
- `dependency_overrides` 中被 pin 的套件（`google_sign_in_ios`、`dio_cookie_manager`）不會有更新 PR，屬預期行為
- 若也想追 GitHub Actions 版本，可另外加一段 `package-ecosystem: "github-actions"`，本 PR 先不含

https://claude.ai/code/session_013k7VfhefnVnGTq98vGhdJ7


___

### **PR Type**
Enhancement


___

### **Description**
- 設定 Dependabot 自動化依賴更新。

- 為 `pub` 生態系啟用每週檢查。

- 為 `bundler` 生態系啟用每月檢查。

- 限制開啟的 PR 數量。


___

