### PR TITLE
feat(login): query student id via stdsys turnstile webview

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ nkust_ap/
 |------|------|
 | `docs/crawler-architecture.md` | 爬蟲分層、ScraperRegistry、Capability 介面、Session 狀態機 |
 | `docs/refactor-scraper-state-design.md` | Scraper 狀態設計決策記錄（ADR 風格） |
+| `docs/student-id-query-turnstile.md` | 學號查詢改走 stdsys + Cloudflare Turnstile 的背景與 WebView 實作 |
 | `docs/cookie-handling.md` | Cookie / `SafeCookieManager` 行為 |
 | `docs/changelog-pipeline.md` | PR → `changelog.json` → Fastlane 變更紀錄管線 |
 | `docs/extracting-flutter-crawler-as-dart-package.md` | 將爬蟲抽離成獨立 Dart package 的流程（reusable guide） |

--- a/assets_test/stdsys/query_student_id_bot_failed.html
+++ b/assets_test/stdsys/query_student_id_bot_failed.html
@@ -1,0 +1,167 @@
+HTTP/2 200 
+cache-control: no-cache, no-store
+pragma: no-cache
+content-type: text/html; charset=utf-8
+server: Microsoft-IIS/10.0
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+content-security-policy: frame-ancestors 'self' https://webap0.nkust.edu.tw https://webap.nkust.edu.tw
+set-cookie: XSRF-TOKEN=CfDJ8MEQwsvvZn5FtbJZ_8POIvbPntfQQrZsmv9BBAttij3cC94MDcqD_qwqbX5dCJB8_JC8pjput4_brd1rmWHp3LlWMv_WAzod4FBhGCgfzJX_ZN61V1LRciOXNZBY017P_CRgSToHaPoLlCOruJLEaNA; path=/
+x-frame-options: SAMEORIGIN
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+date: Thu, 03 Sep 2026 09:22:44 GMT
+
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>Nkust</title>
+    <link rel="shortcut icon" href="/student/img/favicon.ico">
+<link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,700" rel="stylesheet" />
+
+
+    <link rel="stylesheet" href="/student/_content/Nkust.Web.Core/libs/sweetalert2/dist/sweetalert2.min.css" />
+    <link href="/student/_content/Nkust.Web.Core/libs/font-awesome/css/all.min.css?v=Mg1XLfuETnFSSAt7YjdCNsSJbMyjrJ1puwPzvCA0rLg" rel="stylesheet" />
+    <link href="/student/_content/Nkust.Web.Core/libs/icheck-bootstrap/icheck-bootstrap.css?v=nGN1DgpDTrAS3DS7E5J0cL-gblWBKAMSoU_LSuY8gu8" rel="stylesheet" />
+    <link href="/student/_content/Nkust.Web.Core/libs/admin-lte/dist/css/adminlte.min.css?v=gm2jB4Crdw1zuiybGdH7svr9LMyenyQV-rCwJHTNS5w" rel="stylesheet" />
+
+    <link href="/student/_content/Nkust.Web.Core/libs/toastr/toastr.css?v=He3QEBKoL_nMXlVsoM7S2C2kjFQqS5L-mgA-F8LpG-U" rel="stylesheet" />
+    <link href="/student/libs-ext/famfamfam-flags/dist/sprite/famfamfam-flags.min.css?v=D9O-28vCF-qJh2qZSFIXxXc30hTED8RmnKeZRyvVEpA" rel="stylesheet" />
+
+    <link href="/student/view-resources/Views/Account/_Layout.css?v=pHobCa-IAfjMNqE8x1a2vYglVfPFWGtvFJmb0671Np0" rel="stylesheet" />
+    <link href="/student/css/style.css?v=4lZM0wjJ2dQ7A_s0DqJZvDRfKrl2g7nHv4nvpfkfmQw" rel="stylesheet" />
+
+
+
+    <style>        
+        .btn-info {
+            color: white;
+            background-color: #17a2b8 !important;
+            border-color: #17a2b8 !important;
+        }
+
+        .text-info {
+            color: #17a2b8 !important;
+        }
+        .blank_height {
+            height: 0px;
+        }
+
+        @media(min-height:600px) {
+            .blank_height {
+                height: 120px;
+            }
+        }
+
+        @media(min-height:800px) {
+            .blank_height {
+                height: 220px;
+            }
+        }
+
+        @media(min-height:900px) {
+            .blank_height {
+                height: 320px;
+            }
+        }
+    </style>   
+       
+</head>
+<body class="hold-transition login-page">
+    <div class="container h-100 d-flex justify-content-center">
+        <div class="">
+            <div class="login-logo">
+                <div class="text-center mt-3">
+                    <img src="https://www.nkust.edu.tw/var/file/0/1000/img/513/539900619.png" width="300"  alt="Nkust Logo">
+                    <h4 class="text-center mt-4 text-info fw-bold mb-0">
+                        學生學號查詢結果<span class='text-danger'></span>
+                    </h4>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-12">
+                    <div class="card">
+                        <div class="card-body">
+                                <div class="alert alert-danger" role="alert">
+                                    &#x767B;&#x5165;&#x5931;&#x6557;&#xFF01;&#x4E0D;&#x7576;&#x767B;&#x5165;&#xFF01;&#x6A5F;&#x5668;&#x4EBA;&#x9A57;&#x8B49;&#x5931;&#x6557;&#xFF01; 
+                                </div>
+                            <div class="text-end">
+                                <button type="button" class="btn btn-link" onclick="history.back();"><i class="fas fa-arrow-left">回上頁</i></button>
+                            </div>
+                            <div>
+                                <ul>
+                                <li>
+                                <span class="text-info">※相關問題：請洽教務處註冊組。</span>
+                                </li>
+                                 <li>
+                                        <span class="text-info">※新生學號查詢，請先至新生專區確認各入學管道開放查詢時間。</span>
+                                 </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="row col-12">                
+                &nbsp;                
+            </div>
+            <div class="row">
+                <div class="col-md-12 text-center">
+                    <p />
+                    <span style="font-size:10px">
+                        <strong>&copy; <a href="http://www.nkust.edu.tw" class="text-decoration-none">國立高雄科技大學</a> 版權所有.  電算與網路中心軟體發展組設計開發.</strong>
+                    </span>
+                    <br />
+                    <span style="font-size:8px">Copyright &copy; 2023 Computer and Network Center. All rights reserved</span>
+                </div>
+            </div>
+            <div class="blank_height" style="">
+                &nbsp;
+            </div>
+        </div>
+    </div>
+    
+
+    <script src="/student/_content/Nkust.Web.Core/libs/jquery/jquery.js?v=eKhayi8LEQwp4NKxN-CfCh-3qOVUtJn3QNZ0TciWLP4"></script>
+
+    <script src="/student/libs/bootstrap/dist/js/bootstrap.bundle.js?v=Qesn0fIyfJA0VfGtzm0Kga5Ro9eCzokdNoMPke7bSxE"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/admin-lte/dist/js/adminlte.min.js?v=x5Mj2wYeSa9WVOK-EK8Z5rmXHFZ-MOY8r4eW8AKzpXU"></script>
+
+    <script src="/student/_content/Nkust.Web.Core/libs/block-ui/jquery.blockUI.js?v=oQaw-JJuUcJQ9QVYMcFnPxICDT-hv8-kuxT2FNzTGhc"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/spin/spin.js?v=GySbz3oZXNlwoawo5PpYy0iM38B-q3jyi_HLw00uxy0"></script>
+    <script src="/student/libs-ext/spin/jquery.spin.js?v=i7H7HL08ldqUANgfQInE7LlU2uWUdQMCJ-Q7-_zLutY"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/sweetalert2/dist/sweetalert2.all.min.js"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/toastr/toastr.min.js?v=yNbKY1y6h2rbVcQtf0b8lq4a-xpktyFc3pSYoGAY1qQ"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/moment/moment-with-locales.js?v=Np7WIE3NI3P2GL_AJrelExNN-VAKrmfFINaLSg17MTQ"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/abp-web-resources/Abp/Framework/scripts/abp.min.js"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/abp-web-resources/Abp/Framework/scripts/libs/abp.jquery.min.js"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/abp-web-resources/Abp/Framework/scripts/libs/abp.toastr.min.js"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/abp-web-resources/Abp/Framework/scripts/libs/abp.blockUI.min.js"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/abp-web-resources/Abp/Framework/scripts/libs/abp.sweet-alert2.min.js"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/abp-web-resources/Abp/Framework/scripts/libs/abp.spin.min.js"></script>
+
+    <script src="/student/_content/Nkust.Web.Core/libs/jquery-validate/jquery.validate.min.js?v=umbTaFxP31Fv6O1itpLS_3-v5fOAWDLOUzlmvOGaKV4"></script>
+    <script src="/student/_content/Nkust.Web.Core/libs/jquery-validate/jquery.validate.unobtrusive.min.js?v=RFWFWIIPsjB4DucR4jqwxTWw13ZmtI-s6tVR2LJmZXk"></script>
+
+    <script src="/student/_content/Nkust.Web.Core/js/utilities.js?v=dML2DqL5niomJB8hWeHwDnrZkBEszN0hGIkKyDT0HTQ"></script>
+
+
+
+
+    <script src="/student/_content/Nkust.Web.Core/libs/jquery-validate/localization/messages_zh_TW.min.js?v=dVl5CRbQ8cGuneBb6sgpVSsEEYeegHZ6M0TOcgSPBY8"></script>
+
+<script type="text/javascript">
+        // Localizing momentjs
+        moment.locale('zh-TW');
+</script>
+
+<!-- Dynamic scripts of ABP system (They are created on runtime and can not be bundled) -->
+<script src="/student/AbpServiceProxies/GetAll?v=639240309034919526" type="text/javascript"></script>
+<script src="/student/AbpScripts/GetScripts?v=639240309034919526" type="text/javascript"></script>
+</body>
+</html>
+
+
+

--- a/docs/student-id-query-turnstile.md
+++ b/docs/student-id-query-turnstile.md
@@ -1,0 +1,91 @@
+# 學號查詢改走 stdsys + Cloudflare Turnstile
+
+## 背景與問題
+
+學號查詢原本打 `webap.nkust.edu.tw`：先抓 `validateCode_foruid.jsp` 的 captcha 圖，用 `EuclideanCaptchaSolver` 做 template matching OCR，再帶著答案 POST `system/getuid_1.jsp`，最多重試 5 次。
+
+學校把這個功能搬到 `https://stdsys.nkust.edu.tw/student/QueryStudentId`（ASP.NET Core），新頁的驗證方式換成 **Cloudflare Turnstile**，而且是 server-side 驗：
+
+```
+POST /student/QueryStudentId/ShowResult
+IdNo=<身分證號>&Birthday=<民國 YYYMMDD>&__RequestVerificationToken=<antiforgery>
+```
+
+實測帶正確的 antiforgery token、但不帶 `cf-turnstile-response`，server 回：
+
+> 登入失敗！不當登入！機器人驗證失敗！
+
+也就是說**純 HTTP 爬不過去**。Turnstile 的 token 只能由真的 browser engine 跑完 challenge 才拿得到，不像舊的圖形 captcha 可以本機 OCR。
+
+## 方案選擇
+
+| 方案 | 結論 |
+|------|------|
+| 繼續用 webap OCR 路徑 | 目前還活著，但學校已把功能搬走，屬於隨時會關的舊介面；留兩套只會兩套都腐爛 |
+| 用第三方 captcha solving 服務 | 要錢、要把使用者身分證號送去第三方，隱私上不可接受 |
+| **WebView 跑 challenge**（採用） | 沿用 `flutter_inappwebview`（leave 登入已在用），token 由 Cloudflare 直接發給頁面，App 端不碰任何驗證邏輯 |
+
+## 怎麼做
+
+輸入 UX 沿用原生表單（身分證號欄位 + 生日 date picker + 「自動填入」勾選），只有 challenge 那段進 WebView：
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as 使用者
+  participant P as SearchStudentIdPage
+  participant W as QueryStudentIdWebViewPage
+  participant S as stdsys.nkust.edu.tw
+  participant CF as challenges.cloudflare.com
+
+  U->>P: 填身分證號 + 生日，按查詢
+  P->>W: push(rocId, birthday)
+  W->>S: GET /student/QueryStudentId
+  S-->>W: 表單 + antiforgery cookie/token + .cf-turnstile
+  W->>W: JS 填入 IdNo / Birthday（民國 YYYMMDD）
+  W->>CF: challenge（iframe，必要時使用者互動）
+  CF-->>W: cf-turnstile-response token
+  W->>W: 輪詢到 token 有值 → form.submit()
+  W->>S: POST /student/QueryStudentId/ShowResult
+  S-->>W: 結果頁（姓名 / 學號，或錯誤 alert）
+  W->>W: outerHTML → StdsysParser.queryStudentIdResultParser
+  W-->>P: pop(StudentIdQueryResult)
+  P->>U: 自動填入學號，或顯示結果 / 錯誤 dialog
+```
+
+### WebView 端的三個地雷
+
+這三點官方文件都有列，漏掉任何一項 challenge 都會卡死：<https://developers.cloudflare.com/turnstile/get-started/mobile-implementation/>
+
+1. **Android 要開 third-party cookies** — challenge 跑在 iframe 內屬 third-party context，Android WebView 預設擋掉它的 cookie，challenge 就永遠過不了。對應設定是 `InAppWebViewSettings(thirdPartyCookiesEnabled: true)`。
+2. **`about:blank` / `about:srcdoc` 必須放行** — challenge widget 會用這些 scheme 建巢狀 iframe。
+3. **host 比對的外部連結判斷只能套在 main frame** — 否則 `challenges.cloudflare.com` 的 subframe 會被當外部連結丟出 App。本頁面沒有任何往外的連結需求，所以直接 `useShouldOverrideUrlLoading: false` 完全不攔，是最安全的做法。
+
+另外 `clearCache: true`：每次查詢都要新的 antiforgery cookie/token 配對，快取頁面會拿到已用掉的 Turnstile token。
+
+### 自動送出
+
+Turnstile widget 是從 `.cf-turnstile` 隱式渲染、沒有 `data-callback`，所以沒有 callback 可掛。注入的 JS 改用輪詢 hidden field `[name="cf-turnstile-response"]`，一有值就 `form.submit()`。非互動式 challenge 的情況下使用者完全不需要動作。
+
+### 結果解析
+
+`StdsysParser.queryStudentIdResultParser` 吃結果頁 HTML，回傳 `StudentIdQueryResult`：
+
+- 成功：以 `姓名` / `學號` 標籤配對取值。結果頁沒有穩定的 id 或 data attribute，比對標籤而不是 markup，學校改版時比較不容易壞；element 邊界會被轉成空白，所以「同一個 text node」與「相鄰 table cell」兩種寫法都吃得下。
+- 失敗：取 `.alert` 的文字當訊息（查無此人、機器人驗證失敗等），直接顯示 server 的原文。
+
+測試在 `test/api_parser_test.dart`，失敗頁是真實抓下來的 fixture（`assets_test/stdsys/query_student_id_bot_failed.html`）；成功頁需要有效身分證號才抓得到，所以是 synthetic markup，並刻意涵蓋上述兩種排版。
+
+## 影響範圍
+
+- 移除 `NKUSTHelper.getUsername` / `getUidValidationImage` / `NKUSTHelper.captchaSolver` 與 `Helper.searchUsername`（webap OCR 路徑整條刪掉）。
+- `EuclideanCaptchaSolver` 保留 — `WebApHelper` 的登入流程還在用。
+- 新增 `lib/pages/query_student_id_web_view_page.dart`、`StudentIdQueryResult`、`StdsysParser.queryStudentIdResultParser`。
+
+## 待驗證
+
+成功頁的實際 markup 尚未取得（需要有效身分證號 + 生日）。第一次用真實資料查詢時要確認 `queryStudentIdResultParser` 抓到的 `id` / `name` 正確，必要時把真實 fixture 補進 `assets_test/stdsys/`。
+
+## 變更歷史
+
+- 2026-09-03：改用 stdsys + Turnstile WebView 流程，移除 webap OCR 路徑。

--- a/lib/integrations/crawler/crawler_bootstrap.dart
+++ b/lib/integrations/crawler/crawler_bootstrap.dart
@@ -39,7 +39,6 @@ void bootstrapCrawler() {
   final EuclideanCaptchaSolver captchaSolver =
       EuclideanCaptchaSolver(const AssetCaptchaTemplateProvider());
   WebApHelper.instance.captchaSolver = captchaSolver;
-  NKUSTHelper.instance.captchaSolver = captchaSolver;
 
   StdsysHelper.instance.pdfTextExtractor = const SyncfusionPdfTextExtractor();
 

--- a/lib/l10n/en.i18n.json
+++ b/lib/l10n/en.i18n.json
@@ -117,6 +117,8 @@
   "needHelp": "Need Help?",
   "selectReportOption": "Select an option below to report an issue or provide suggestions",
   "searchStudentId": "Search Student ID",
+  "studentIdQueryVerify": "Student ID Verification",
+  "studentIdQueryVerifyHint": "Complete the robot check; the query runs automatically once it passes.",
   "studentIdBarcode": "Student ID Barcode",
   "useStudentIdInLibrary": "Use this student ID in the library",
   "tapToLogin": "Tap to Login",

--- a/lib/l10n/generated/strings.g.dart
+++ b/lib/l10n/generated/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 621 (207 per locale)
+/// Strings: 627 (209 per locale)
 ///
-/// Built on 2026-05-01 at 05:59 UTC
+/// Built on 2026-09-03 at 09:30 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/lib/l10n/generated/strings_en.g.dart
+++ b/lib/l10n/generated/strings_en.g.dart
@@ -157,6 +157,8 @@ class NkustLocalizationsEn extends NkustLocalizations with BaseTranslations<Nkus
 	@override String get needHelp => 'Need Help?';
 	@override String get selectReportOption => 'Select an option below to report an issue or provide suggestions';
 	@override String get searchStudentId => 'Search Student ID';
+	@override String get studentIdQueryVerify => 'Student ID Verification';
+	@override String get studentIdQueryVerifyHint => 'Complete the robot check; the query runs automatically once it passes.';
 	@override String get studentIdBarcode => 'Student ID Barcode';
 	@override String get useStudentIdInLibrary => 'Use this student ID in the library';
 	@override String get tapToLogin => 'Tap to Login';
@@ -374,6 +376,8 @@ extension on NkustLocalizationsEn {
 			'needHelp' => 'Need Help?',
 			'selectReportOption' => 'Select an option below to report an issue or provide suggestions',
 			'searchStudentId' => 'Search Student ID',
+			'studentIdQueryVerify' => 'Student ID Verification',
+			'studentIdQueryVerifyHint' => 'Complete the robot check; the query runs automatically once it passes.',
 			'studentIdBarcode' => 'Student ID Barcode',
 			'useStudentIdInLibrary' => 'Use this student ID in the library',
 			'tapToLogin' => 'Tap to Login',

--- a/lib/l10n/generated/strings_ja.g.dart
+++ b/lib/l10n/generated/strings_ja.g.dart
@@ -139,6 +139,8 @@ class NkustLocalizationsJa extends NkustLocalizations with BaseTranslations<Nkus
 	@override String get needHelp => 'お困りですか？';
 	@override String get selectReportOption => '問題を報告または提案してください';
 	@override String get searchStudentId => '学籍番号検索';
+	@override String get studentIdQueryVerify => '学籍番号照会の認証';
+	@override String get studentIdQueryVerifyHint => 'ロボット認証を完了してください。通過後に自動で照会します。';
 	@override String get studentIdBarcode => '学生証バーコード';
 	@override String get useStudentIdInLibrary => '図書館でこの学籍番号を使用';
 	@override String get tapToLogin => 'タップしてログイン';
@@ -356,6 +358,8 @@ extension on NkustLocalizationsJa {
 			'needHelp' => 'お困りですか？',
 			'selectReportOption' => '問題を報告または提案してください',
 			'searchStudentId' => '学籍番号検索',
+			'studentIdQueryVerify' => '学籍番号照会の認証',
+			'studentIdQueryVerifyHint' => 'ロボット認証を完了してください。通過後に自動で照会します。',
 			'studentIdBarcode' => '学生証バーコード',
 			'useStudentIdInLibrary' => '図書館でこの学籍番号を使用',
 			'tapToLogin' => 'タップしてログイン',

--- a/lib/l10n/generated/strings_zh_Hant_TW.g.dart
+++ b/lib/l10n/generated/strings_zh_Hant_TW.g.dart
@@ -389,6 +389,12 @@ class NkustLocalizations with BaseTranslations<NkustLocale, NkustLocalizations> 
 	/// zh-Hant-TW: '查詢學號'
 	String get searchStudentId => '查詢學號';
 
+	/// zh-Hant-TW: '學號查詢驗證'
+	String get studentIdQueryVerify => '學號查詢驗證';
+
+	/// zh-Hant-TW: '請完成機器人驗證，通過後會自動查詢'
+	String get studentIdQueryVerifyHint => '請完成機器人驗證，通過後會自動查詢';
+
 	/// zh-Hant-TW: '學生證條碼'
 	String get studentIdBarcode => '學生證條碼';
 
@@ -783,6 +789,8 @@ extension on NkustLocalizations {
 			'needHelp' => '需要幫助嗎？',
 			'selectReportOption' => '選擇下方選項來回報問題或提供建議',
 			'searchStudentId' => '查詢學號',
+			'studentIdQueryVerify' => '學號查詢驗證',
+			'studentIdQueryVerifyHint' => '請完成機器人驗證，通過後會自動查詢',
 			'studentIdBarcode' => '學生證條碼',
 			'useStudentIdInLibrary' => '請於圖書館使用此學號',
 			'tapToLogin' => '點擊登入',

--- a/lib/l10n/ja.i18n.json
+++ b/lib/l10n/ja.i18n.json
@@ -99,6 +99,8 @@
   "needHelp": "お困りですか？",
   "selectReportOption": "問題を報告または提案してください",
   "searchStudentId": "学籍番号検索",
+  "studentIdQueryVerify": "学籍番号照会の認証",
+  "studentIdQueryVerifyHint": "ロボット認証を完了してください。通過後に自動で照会します。",
   "studentIdBarcode": "学生証バーコード",
   "useStudentIdInLibrary": "図書館でこの学籍番号を使用",
   "tapToLogin": "タップしてログイン",

--- a/lib/l10n/zh_Hant_TW.i18n.json
+++ b/lib/l10n/zh_Hant_TW.i18n.json
@@ -117,6 +117,8 @@
   "needHelp": "需要幫助嗎？",
   "selectReportOption": "選擇下方選項來回報問題或提供建議",
   "searchStudentId": "查詢學號",
+  "studentIdQueryVerify": "學號查詢驗證",
+  "studentIdQueryVerifyHint": "請完成機器人驗證，通過後會自動查詢",
   "studentIdBarcode": "學生證條碼",
   "useStudentIdInLibrary": "請於圖書館使用此學號",
   "tapToLogin": "點擊登入",

--- a/lib/pages/query_student_id_web_view_page.dart
+++ b/lib/pages/query_student_id_web_view_page.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+
+import 'package:ap_common/ap_common.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:nkust_ap/l10n/nkust_localizations.dart';
+import 'package:nkust_crawler/nkust_crawler.dart';
+import 'package:sprintf/sprintf.dart';
+
+/// Drives the student-id lookup on stdsys inside a WebView and pops a
+/// [StudentIdQueryResult].
+///
+/// The page is fronted by Cloudflare Turnstile and the token is verified
+/// server-side, so a plain HTTP POST always comes back with
+/// 「機器人驗證失敗」 — the challenge has to run in a real browser engine.
+/// Id and birthday are injected from the native form so the only thing left
+/// for the user is the challenge itself, and the form is submitted as soon as
+/// Turnstile hands out a token (which for a non-interactive challenge means no
+/// user action at all).
+class QueryStudentIdWebViewPage extends StatefulWidget {
+  const QueryStudentIdWebViewPage({
+    super.key,
+    required this.rocId,
+    required this.birthday,
+  });
+
+  static const String routerName = '/queryStudentId';
+
+  static const String queryUrl =
+      'https://stdsys.nkust.edu.tw/student/QueryStudentId';
+  static const String resultPath = '/student/QueryStudentId/ShowResult';
+
+  /// 身分證號, goes into the `IdNo` field.
+  final String rocId;
+
+  /// Goes into the `Birthday` field as ROC-calendar `YYYMMDD`.
+  final DateTime birthday;
+
+  @override
+  State<QueryStudentIdWebViewPage> createState() =>
+      _QueryStudentIdWebViewPageState();
+}
+
+class _QueryStudentIdWebViewPageState extends State<QueryStudentIdWebViewPage> {
+  /// Turnstile serves a different (or no) challenge to non-browser user
+  /// agents, so keep a plain desktop Chrome string here.
+  static const String _userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+      '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+
+  bool _finished = false;
+  bool _isLoading = true;
+  bool _hintShown = false;
+
+  String get _birthdayText => sprintf('%03i%02i%02i', <int>[
+        widget.birthday.year - 1911,
+        widget.birthday.month,
+        widget.birthday.day,
+      ]);
+
+  @override
+  Widget build(BuildContext context) {
+    final NkustLocalizations app = context.t;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(app.studentIdQueryVerify),
+        bottom: _isLoading
+            ? const PreferredSize(
+                preferredSize: Size.fromHeight(4),
+                child: LinearProgressIndicator(minHeight: 4),
+              )
+            : null,
+      ),
+      body: InAppWebView(
+        initialUrlRequest: URLRequest(
+          url: WebUri(QueryStudentIdWebViewPage.queryUrl),
+        ),
+        initialSettings: InAppWebViewSettings(
+          userAgent: _userAgent,
+          // Every attempt needs a fresh antiforgery cookie / token pair, and a
+          // cached page would replay a spent Turnstile token.
+          clearCache: true,
+          // Turnstile renders the challenge in an iframe, which on Android is
+          // a third-party context — WebView blocks its cookies by default and
+          // the challenge then never completes.
+          // https://developers.cloudflare.com/turnstile/get-started/mobile-implementation/
+          thirdPartyCookiesEnabled: true,
+          // Deliberately left off: the challenge builds nested `about:blank` /
+          // `about:srcdoc` iframes and loads challenges.cloudflare.com in a
+          // subframe. Any navigation interception has to let those through, so
+          // the safest thing on a page that never links outwards is to not
+          // intercept at all.
+          useShouldOverrideUrlLoading: false,
+        ),
+        onLoadStart: (_, __) {
+          if (mounted) setState(() => _isLoading = true);
+        },
+        onLoadStop: (InAppWebViewController controller, WebUri? url) async {
+          if (mounted) setState(() => _isLoading = false);
+          if (url == null) return;
+
+          if (url.path == QueryStudentIdWebViewPage.resultPath) {
+            await _finish(controller);
+            return;
+          }
+
+          if (url.path == WebUri(QueryStudentIdWebViewPage.queryUrl).path) {
+            await _fillForm(controller);
+            await _autoSubmitWhenChallenged(controller);
+            if (!_hintShown && mounted) {
+              _hintShown = true;
+              UiUtil.instance.showToast(context, app.studentIdQueryVerifyHint);
+            }
+          }
+        },
+        onReceivedError: (_, __, WebResourceError error) {
+          if (mounted) setState(() => _isLoading = false);
+          debugPrint('QueryStudentId onReceivedError: ${error.description}');
+        },
+      ),
+    );
+  }
+
+  Future<void> _fillForm(InAppWebViewController controller) async {
+    await controller.evaluateJavascript(
+      source: '''
+(function () {
+  var id = document.getElementById('IdNo');
+  var birthday = document.getElementById('Birthday');
+  if (!id || !birthday) return;
+  id.value = ${jsonEncode(widget.rocId)};
+  birthday.value = ${jsonEncode(_birthdayText)};
+  id.dispatchEvent(new Event('input', { bubbles: true }));
+  birthday.dispatchEvent(new Event('input', { bubbles: true }));
+})();
+''',
+    );
+  }
+
+  /// Submits the form once Turnstile writes its token into the hidden
+  /// `cf-turnstile-response` field. There is no callback to hook into — the
+  /// widget is rendered implicitly from `.cf-turnstile`, without
+  /// `data-callback` — so polling the field is the only handle we get.
+  Future<void> _autoSubmitWhenChallenged(
+    InAppWebViewController controller,
+  ) async {
+    await controller.evaluateJavascript(
+      source: '''
+(function () {
+  if (window.__nkustAutoSubmit) return;
+  window.__nkustAutoSubmit = true;
+  var timer = setInterval(function () {
+    var token = document.querySelector('[name="cf-turnstile-response"]');
+    var form = document.getElementById('LoginForm');
+    if (!form || !token || !token.value) return;
+    clearInterval(timer);
+    form.submit();
+  }, 300);
+})();
+''',
+    );
+  }
+
+  Future<void> _finish(InAppWebViewController controller) async {
+    if (_finished) return;
+    _finished = true;
+
+    final Object? html = await controller.evaluateJavascript(
+      source: 'document.documentElement.outerHTML',
+    );
+    final StudentIdQueryResult result =
+        StdsysParser.instance.queryStudentIdResultParser(html as String?);
+
+    if (!mounted) return;
+    Navigator.pop(context, result);
+  }
+}

--- a/lib/pages/search_student_id_page.dart
+++ b/lib/pages/search_student_id_page.dart
@@ -1,6 +1,7 @@
 import 'package:ap_common/ap_common.dart';
 import 'package:flutter/material.dart';
 import 'package:nkust_crawler/nkust_crawler.dart';
+import 'package:nkust_ap/pages/query_student_id_web_view_page.dart';
 import 'package:nkust_ap/res/assets.dart';
 import 'package:nkust_ap/utils/global.dart';
 import 'package:sprintf/sprintf.dart';
@@ -160,33 +161,39 @@ class SearchStudentIdPageState extends State<SearchStudentIdPage> {
     setState(() => isSearching = true);
     AnalyticsUtil.instance.logEvent('search_username_click');
 
-    try {
-      final UserInfo data = await Helper.instance.searchUsername(
-        rocId: _id.text,
-        birthday: birthday,
-      );
-      if (!mounted) return;
-      setState(() => isSearching = false);
-      if (isAutoFill) {
-        Navigator.pop(context, data.id);
-      } else {
-        _showResultDialog(
-          context.t.searchStudentIdFormat(
-            name: data.name ?? '',
-            id: data.id,
-          ),
-        );
-      }
-    } on ApException catch (e) {
-      if (!mounted) return;
-      setState(() => isSearching = false);
-      if (e is CancelledException) return;
-      // 404 means "no match found" — surface the server's own message
-      // (e.g. "查無此人") instead of the generic ap.unknownError.
-      final bool isNotFound = e is ServerException && e.httpStatusCode == 404;
+    final StudentIdQueryResult? result =
+        await Navigator.push<StudentIdQueryResult>(
+      context,
+      MaterialPageRoute<StudentIdQueryResult>(
+        builder: (_) => QueryStudentIdWebViewPage(
+          rocId: _id.text,
+          birthday: birthday,
+        ),
+      ),
+    );
+
+    if (!mounted) return;
+    setState(() => isSearching = false);
+
+    // Popped without a result — the user backed out of the challenge page.
+    if (result == null) return;
+
+    if (!result.isSuccess) {
       _showResultDialog(
-        isNotFound ? e.message : context.ap.unknownError,
+        result.message ?? context.ap.unknownError,
         showFirstHint: false,
+      );
+      return;
+    }
+
+    if (isAutoFill) {
+      Navigator.pop(context, result.id);
+    } else {
+      _showResultDialog(
+        context.t.searchStudentIdFormat(
+          name: result.name ?? '',
+          id: result.id!,
+        ),
       );
     }
   }

--- a/packages/nkust_crawler/lib/nkust_crawler.dart
+++ b/packages/nkust_crawler/lib/nkust_crawler.dart
@@ -66,6 +66,7 @@ export 'src/models/models.dart';
 export 'src/models/reward_and_penalty_data.dart';
 export 'src/models/room_data.dart';
 export 'src/models/schedule_data.dart';
+export 'src/models/student_id_query_result.dart';
 
 // Parsers
 export 'src/parsers/ap_parser.dart';

--- a/packages/nkust_crawler/lib/src/facade/helper.dart
+++ b/packages/nkust_crawler/lib/src/facade/helper.dart
@@ -533,18 +533,6 @@ class Helper {
     });
   }
 
-  Future<UserInfo> searchUsername({
-    required String rocId,
-    required DateTime birthday,
-  }) async {
-    return _call(() async {
-      return NKUSTHelper.instance.getUsername(
-        rocId: rocId,
-        birthday: birthday,
-      );
-    });
-  }
-
   Future<LeaveData> getLeaves({
     required Semester semester,
   }) async {

--- a/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
+++ b/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
@@ -1,30 +1,17 @@
-import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:ap_common_core/ap_common_core.dart';
 import 'package:cookie_jar/cookie_jar.dart';
-import 'package:html/dom.dart';
-import 'package:html/parser.dart';
-import 'package:http/http.dart' as http;
-import 'package:nkust_crawler/src/abstractions/captcha_solver.dart';
 import 'package:nkust_crawler/src/config/api_config.dart';
 import 'package:nkust_crawler/src/exceptions/api_exception.dart';
 import 'package:nkust_crawler/src/parsers/nkust_parser.dart';
-import 'package:sprintf/sprintf.dart';
 
 class NKUSTHelper {
   static NKUSTHelper? _instance;
 
   late Dio dio;
   late CookieJar cookieJar;
-
-  /// Captcha solver injected by the host app (defaults to a stub that
-  /// always throws — host must wire a real implementation before login
-  /// flows that need a captcha).
-  CaptchaSolver? captchaSolver;
 
   //ignore: prefer_constructors_over_static_methods
   static NKUSTHelper get instance {
@@ -43,141 +30,6 @@ class NKUSTHelper {
     final (:dio, :cookieJar) = ApiConfig.createScraperDio();
     this.dio = dio;
     this.cookieJar = cookieJar;
-  }
-
-  Future<Uint8List?> getUidValidationImage() async {
-    final Response<Uint8List> response = await dio.get<Uint8List>(
-      'https://webap.nkust.edu.tw/nkust/validateCode_foruid.jsp',
-      options: Options(
-        responseType: ResponseType.bytes,
-        headers: <String, dynamic>{
-          'Referer': 'https://webap.nkust.edu.tw/',
-        },
-      ),
-    );
-    return response.data;
-  }
-
-  Future<UserInfo> getUsername({
-    required String rocId,
-    required DateTime birthday,
-    int retryCounts = 5,
-  }) async {
-    final String birthdayText = sprintf('%03i%02i%02i', <int>[
-      birthday.year - 1911,
-      birthday.month,
-      birthday.day,
-    ]);
-
-    assert(retryCounts >= 0, 'retryCounts must be >= 0');
-
-    Object? lastError;
-
-    for (int i = 0; i < retryCounts; i++) {
-      try {
-        final Uint8List? imageBytes = await getUidValidationImage();
-
-        if (imageBytes == null) {
-          continue;
-        }
-
-        final solver = captchaSolver;
-        if (solver == null) {
-          throw StateError(
-            'NKUSTHelper.captchaSolver is not configured. '
-            'Wire a CaptchaSolver implementation at app bootstrap.',
-          );
-        }
-        final String captchaCode = await solver.solve(imageBytes);
-
-        final List<Cookie> cookies = await cookieJar
-            .loadForRequest(Uri.parse('https://webap.nkust.edu.tw'));
-        final String cookieHeader = cookies
-            .map((Cookie cookie) => '${cookie.name}=${cookie.value}')
-            .join('; ');
-
-        final http.Response response = await http.post(
-          Uri(
-            scheme: 'https',
-            host: 'webap.nkust.edu.tw',
-            path: '/nkust/system/getuid_1.jsp',
-            queryParameters: <String, String>{
-              'uid': rocId,
-              'bir': birthdayText,
-              'Text3': captchaCode,
-              'kind': '2',
-            },
-          ),
-          headers: <String, String>{
-            'Connection': 'close',
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Referer': 'https://webap.nkust.edu.tw/',
-            'Cookie': cookieHeader,
-          },
-        );
-
-        if (!response.body.contains('驗證碼')) {
-          final Document document = parse(response.body);
-          final List<Element> elements = document.getElementsByTagName('b');
-
-          if (elements.length >= 4) {
-            final UserInfo userInfo = UserInfo(
-              id: elements[4].text.replaceAll(' ', ''),
-              name: elements[2].text,
-              className: '',
-              department: '',
-            );
-            return userInfo;
-          } else if (elements.length == 1) {
-            throw ServerException(
-              httpStatusCode: 404,
-              message: elements[0].text,
-            );
-          } else {
-            throw ServerException(
-              message: 'unexpected element count in username lookup response',
-            );
-          }
-        }
-      } on ApException {
-        rethrow;
-      } on SocketException catch (e, s) {
-        // package:http wraps transport errors as SocketException /
-        // HandshakeException; translate immediately so the UI shows
-        // "沒有網路連線" rather than the generic "未知錯誤" that _call
-        // would otherwise wrap this as.
-        throw NetworkException(
-          message: e.message,
-          cause: e,
-          causeStackTrace: s,
-        );
-      } on HandshakeException catch (e, s) {
-        throw NetworkException(
-          message: e.message,
-          cause: e,
-          causeStackTrace: s,
-        );
-      } on http.ClientException catch (e, s) {
-        throw NetworkException(
-          message: e.message,
-          cause: e,
-          causeStackTrace: s,
-        );
-      } catch (error) {
-        lastError = error;
-
-        if (i == retryCounts - 1) {
-          rethrow;
-        }
-      }
-    }
-
-    throw CaptchaException(
-      attempts: retryCounts,
-      message: lastError == null
-          ? 'captcha failed after $retryCounts attempts'
-          : 'captcha failed: $lastError',
-    );
   }
 
   Future<NotificationsData> getNotifications(int page) async {

--- a/packages/nkust_crawler/lib/src/models/student_id_query_result.dart
+++ b/packages/nkust_crawler/lib/src/models/student_id_query_result.dart
@@ -1,0 +1,36 @@
+/// Outcome of a student-id lookup on
+/// `stdsys.nkust.edu.tw/student/QueryStudentId`.
+///
+/// The lookup is fronted by Cloudflare Turnstile and verified server-side, so
+/// it cannot be driven by a plain HTTP request — the host app runs it in a
+/// WebView and feeds the resulting page to
+/// [StdsysParser.queryStudentIdResultParser].
+class StudentIdQueryResult {
+  const StudentIdQueryResult.success({
+    required String this.id,
+    this.name,
+  })  : message = null,
+        isSuccess = true;
+
+  const StudentIdQueryResult.failure([this.message])
+      : id = null,
+        name = null,
+        isSuccess = false;
+
+  final bool isSuccess;
+
+  /// Student id, only set when [isSuccess].
+  final String? id;
+
+  /// Student name, only set when [isSuccess] and the page exposed it.
+  final String? name;
+
+  /// Message rendered by the server (e.g. 查無此人 / 機器人驗證失敗), only set
+  /// when the lookup failed.
+  final String? message;
+
+  @override
+  String toString() => isSuccess
+      ? 'StudentIdQueryResult.success(id: $id, name: $name)'
+      : 'StudentIdQueryResult.failure($message)';
+}

--- a/packages/nkust_crawler/lib/src/parsers/stdsys_parser.dart
+++ b/packages/nkust_crawler/lib/src/parsers/stdsys_parser.dart
@@ -6,6 +6,7 @@ import 'package:html/dom.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:ap_common_core/ap_common_core.dart';
 import 'package:nkust_crawler/src/abstractions/crash_reporter.dart';
+import 'package:nkust_crawler/src/models/student_id_query_result.dart';
 import 'package:nkust_crawler/src/parsers/parser_utils.dart';
 
 class StdsysParser {
@@ -45,6 +46,57 @@ class StdsysParser {
 
     return data;
   }
+
+  /// Parses the page returned by `POST /student/QueryStudentId/ShowResult`.
+  ///
+  /// The view has no stable ids or data attributes — it renders either a
+  /// bootstrap alert with the server's own message (查無此人 / 機器人驗證失敗)
+  /// or a 姓名 / 學號 pair. Matching on the labels instead of the markup keeps
+  /// this working when the school reshuffles the layout, which it does often.
+  StudentIdQueryResult queryStudentIdResultParser(String? rawHtml) {
+    if (rawHtml == null || rawHtml.isEmpty) {
+      return const StudentIdQueryResult.failure();
+    }
+
+    final Document document = parse(rawHtml);
+    final String text = _flattenText(document.body ?? document.documentElement);
+
+    final RegExpMatch? idMatch =
+        RegExp(r'學號[：:\s]*([A-Za-z]?\d{6,12})').firstMatch(text);
+
+    if (idMatch != null) {
+      final RegExpMatch? nameMatch =
+          RegExp(r'姓名[：:\s]*([^\s：:]{1,20})').firstMatch(text);
+      return StudentIdQueryResult.success(
+        id: idMatch.group(1)!,
+        name: nameMatch?.group(1),
+      );
+    }
+
+    final Element? alert = document.querySelector('.alert');
+    final String message = _collapse(alert?.text ?? '');
+
+    return StudentIdQueryResult.failure(message.isEmpty ? null : message);
+  }
+
+  /// Element boundaries become whitespace, so label and value stay separate
+  /// words no matter whether the server renders them in one text node
+  /// (`姓名：王小明`) or in sibling table cells. [Element.text] glues them
+  /// together and would make the label regexes capture both at once.
+  String _flattenText(Node? node) => _collapse(_writeText(node));
+
+  String _writeText(Node? node) {
+    if (node == null) return '';
+    if (node is Text) return node.text;
+    if (node is Element) {
+      final String tag = node.localName ?? '';
+      if (tag == 'script' || tag == 'style') return '';
+    }
+    return node.nodes.map(_writeText).join(' ');
+  }
+
+  String _collapse(String text) =>
+      text.replaceAll(RegExp(r'\s+'), ' ').trim();
 
   Map<String, dynamic> studentCourseTableParser(dynamic html) {
     dynamic rawHtml;

--- a/packages/nkust_crawler/test/live/authenticated_live_test.dart
+++ b/packages/nkust_crawler/test/live/authenticated_live_test.dart
@@ -59,7 +59,6 @@ void main() {
     final EuclideanCaptchaSolver solver =
         EuclideanCaptchaSolver(FileSystemTemplateProvider(findTemplateDir()));
     WebApHelper.instance.captchaSolver = solver;
-    NKUSTHelper.instance.captchaSolver = solver;
 
     // Verbose HTTP logging so failed parses are debuggable from the test
     // output alone — opt in via NKUST_HTTP_LOG=1 to keep the default

--- a/test/api_parser_test.dart
+++ b/test/api_parser_test.dart
@@ -338,6 +338,60 @@ void main() {
     });
   });
 
+  // ─── StdsysParser: queryStudentIdResultParser ────────────────────────
+  group('StdsysParser.queryStudentIdResultParser', () {
+    test('reports the server message when Turnstile verification fails', () {
+      final String html =
+          File('assets_test/stdsys/query_student_id_bot_failed.html')
+              .readAsStringSync();
+
+      final StudentIdQueryResult result =
+          StdsysParser.instance.queryStudentIdResultParser(html);
+
+      expect(result.isSuccess, isFalse);
+      expect(result.id, isNull);
+      expect(result.message, contains('機器人驗證失敗'));
+    });
+
+    // Synthetic markup: a real success page needs a valid 身分證號 to capture.
+    // Both shapes the view could plausibly render are covered so a layout
+    // change on the school's side is less likely to break the lookup.
+    test('parses 姓名 / 學號 rendered as inline text', () {
+      const String html = '<html><body><div class="card-body">'
+          '<div class="alert alert-success">姓名：王小明　學號：C109123456</div>'
+          '</div></body></html>';
+
+      final StudentIdQueryResult result =
+          StdsysParser.instance.queryStudentIdResultParser(html);
+
+      expect(result.isSuccess, isTrue);
+      expect(result.id, 'C109123456');
+      expect(result.name, '王小明');
+    });
+
+    test('parses 姓名 / 學號 rendered as table cells', () {
+      const String html = '<html><body><table><tbody>'
+          '<tr><td>姓名</td><td>王小明</td></tr>'
+          '<tr><td>學號</td><td>C109123456</td></tr>'
+          '</tbody></table></body></html>';
+
+      final StudentIdQueryResult result =
+          StdsysParser.instance.queryStudentIdResultParser(html);
+
+      expect(result.isSuccess, isTrue);
+      expect(result.id, 'C109123456');
+      expect(result.name, '王小明');
+    });
+
+    test('fails without a message on empty input', () {
+      final StudentIdQueryResult result =
+          StdsysParser.instance.queryStudentIdResultParser('');
+
+      expect(result.isSuccess, isFalse);
+      expect(result.message, isNull);
+    });
+  });
+
   // Legacy bus.kuas.edu.tw parser tests removed along with BusHelper
   // (system retired after the KUAS/NKUST merger).
 


### PR DESCRIPTION
## 變更摘要

學校把學號查詢搬到 `https://stdsys.nkust.edu.tw/student/QueryStudentId`，新頁改用 Cloudflare Turnstile 且是 server-side 驗證，純 HTTP 爬不過去。改成在 WebView 內跑 challenge，並移除舊的 webap OCR captcha 路徑。

對應 ticket：無（跟進校方系統改版）

## 變更內容

- 新增 `QueryStudentIdWebViewPage`：原生表單填完身分證號與生日後 push 這頁，由 JS 灌入 `IdNo` / `Birthday`（民國 YYYMMDD），輪詢 `[name="cf-turnstile-response"]` 一有 token 就送出表單，解析結果後帶學號回原頁。非互動式 challenge 使用者不需任何操作。
- WebView 設定三個 Turnstile 必要條件：`thirdPartyCookiesEnabled: true`（challenge 跑在 iframe，Android 預設擋 third-party cookie 會卡死）、不攔截 navigation（challenge 會用 `about:blank` / `about:srcdoc` 建巢狀 iframe 並載入 `challenges.cloudflare.com`）、`clearCache: true`（每次查詢要新的 antiforgery token 配對，避免重用已失效的 Turnstile token）。
- 新增 `StdsysParser.queryStudentIdResultParser` 與 `StudentIdQueryResult`：比對 `姓名` / `學號` 標籤而非 markup，同時支援「同一 text node」與「相鄰 table cell」兩種排版；失敗時直接顯示 server 原文（查無此人、機器人驗證失敗等）。
- 移除 `NKUSTHelper.getUsername` / `getUidValidationImage` / `NKUSTHelper.captchaSolver` 與 `Helper.searchUsername`。`EuclideanCaptchaSolver` 保留，`WebApHelper` 登入流程仍在用。
- 新增 `docs/student-id-query-turnstile.md`（背景、方案取捨、WebView 地雷、待驗證項目），並登記進 `AGENTS.md` 參考文件表。

## 測試方式

- `flutter analyze`：無新增 error / warning（既有 2 個 unused import warning 不在本次範圍）
- `flutter test`：41 passed，含 4 個 `queryStudentIdResultParser` 測試
- `packages/nkust_crawler`：`dart analyze` 只有 info、`dart test` 14 passed
- 失敗頁 fixture 是真實抓下來的（`assets_test/stdsys/query_student_id_bot_failed.html`）
- **尚待真機驗證**：成功頁需要有效身分證號才拿得到，目前成功路徑的 fixture 是 synthetic。第一次用真實資料查詢時要確認 `id` / `name` 解析正確，並把真實 fixture 補進 `assets_test/stdsys/`。建議在 Android 實機驗 third-party cookie 那條路徑。

## 影響範圍與風險

- 只影響登入頁的「查詢學號」入口，不動任何已登入後的爬蟲流程。
- 舊的 webap OCR endpoint 目前仍存活，但功能已被校方搬走，屬隨時會關的舊介面，因此整條移除而非留成 fallback。
- 不需要 migration；`EuclideanCaptchaSolver` 與 webap 登入不受影響。
- 成功頁 markup 未經真實驗證，若解析不到會顯示錯誤 dialog 而非崩潰，最壞情況是使用者改用網頁查詢。
