### PR TITLE
chore: release v4.1.0

### DIFF
--- a/changelog.json
+++ b/changelog.json
@@ -1,4 +1,14 @@
 {
+  "40045": {
+    "version": "4.1.0",
+    "date": "2026-09-03",
+    "zh-TW": [
+      "學號查詢改用學校新版查詢頁，改善舊版驗證碼辨識失敗導致查不到的問題。"
+    ],
+    "en-US": [
+      "Student ID lookup now uses the school's new query page, fixing failures caused by the old captcha recognition."
+    ]
+  },
   "40044": {
     "version": "4.0.1",
     "date": "2026-05-02",

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter application.
 
 publish_to: none
 
-version: 4.0.0
+version: 4.1.0
 
 environment:
   sdk: '>=3.6.0 <4.0.0'


### PR DESCRIPTION
### **User description**
## 變更摘要

將 pubspec 版號 bump 到 4.1.0，並補上 `changelog.json` 的 40045 entry，供內部測試（Beta）發版使用。

對應 ticket：無

## 變更內容

- `pubspec.yaml`：`4.0.0` → `4.1.0`。master 上的 `aa818151`（scaffold nkust_crawler）曾把版號從 4.0.1 誤改回 4.0.0，導致 master 版號低於已發布的 v4.0.1+40044；這次一併修正。
- `changelog.json`：新增 `40045`（本次 CD 會用的 VERSION_CODE）entry，內容為學號查詢改走學校新版查詢頁。

## 測試方式

不含程式邏輯變更，靠 CI 的 analyze / test / build 驗證即可。

## 影響範圍與風險

- 只動版號與 changelog 資料，不影響任何執行路徑。
- 合併後把 master merge 進 `develop` 即觸發 CD，Beta 版本為 `4.1.0+40045`。
- 已知問題：runner 的 login keychain 處於鎖定狀態，`deploy_macos` 會在 codesign 失敗（`errSecInternalComponent`），連帶讓 `github_release` job 無法執行。macOS TestFlight 與 GitHub pre-release 這次會缺，Android 內部測試與 iOS TestFlight 不受影響。


___

### **PR Type**
Enhancement


___

### **Description**
- 應用程式版本更新至 `4.1.0`。

- 新增 `4.1.0` 的更新日誌條目。

- 學號查詢改用學校新版頁面。

- 解決舊版驗證碼辨識問題。


___

