### PR TITLE
chore(test): strip http headers from the student id fixture

### DIFF
--- a/assets_test/stdsys/query_student_id_bot_failed.html
+++ b/assets_test/stdsys/query_student_id_bot_failed.html
@@ -1,16 +1,3 @@
-HTTP/2 200 
-cache-control: no-cache, no-store
-pragma: no-cache
-content-type: text/html; charset=utf-8
-server: Microsoft-IIS/10.0
-x-content-type-options: nosniff
-x-xss-protection: 1; mode=block
-content-security-policy: frame-ancestors 'self' https://webap0.nkust.edu.tw https://webap.nkust.edu.tw
-set-cookie: XSRF-TOKEN=CfDJ8MEQwsvvZn5FtbJZ_8POIvbPntfQQrZsmv9BBAttij3cC94MDcqD_qwqbX5dCJB8_JC8pjput4_brd1rmWHp3LlWMv_WAzod4FBhGCgfzJX_ZN61V1LRciOXNZBY017P_CRgSToHaPoLlCOruJLEaNA; path=/
-x-frame-options: SAMEORIGIN
-strict-transport-security: max-age=31536000; includeSubDomains; preload
-date: Thu, 03 Sep 2026 09:22:44 GMT
-
 <!DOCTYPE html>
 <html lang="zh-TW">
 <head>


### PR DESCRIPTION
## 變更摘要

移除 `assets_test/stdsys/query_student_id_bot_failed.html` 開頭誤留的 HTTP response header 區塊（620 bytes），只保留 HTML。

對應 ticket：無

## 變更內容

- 該 fixture 是用 `curl -i` 抓的，headers 被一起寫進檔案，其中包含一行 `set-cookie: XSRF-TOKEN=...`。那是抓取時那個丟棄式 session 的 token、早已失效且不含個資，但 HTTP header 與 cookie 值不該留在 HTML fixture 裡。
- 內容其餘不變，parser 測試照樣通過（`parse()` 原本就容忍那段雜訊，所以先前沒被發現）。

## 測試方式

`flutter test` 44 passed。

## 影響範圍與風險

僅測試 fixture，不影響任何執行路徑。