### PR TITLE
fix(crawler): repair acad announcements after site revamp

### DIFF
--- a/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
+++ b/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
@@ -26,6 +26,19 @@ class NKUSTHelper {
   /// flows that need a captcha).
   CaptchaSolver? captchaSolver;
 
+  /// acad's mobile list endpoint no longer paginates server-side — it
+  /// hands back the whole (~200 row) list in one response and 302s for
+  /// `Page >= 2` — so the full list is fetched once, deduped, and
+  /// windowed client-side. Without this, an infinite-scroll list would
+  /// re-download and re-parse the entire feed for every page turn.
+  List<Map<String, dynamic>>? _acadCache;
+  DateTime? _acadCachedAt;
+  static const Duration _acadCacheTtl = Duration(minutes: 10);
+
+  /// The academic-affairs announcement category (`Rcg`). It changed once
+  /// already (232 -> 2072) and broke this feed, so keep it in one place.
+  static const int _acadRcg = 2072;
+
   //ignore: prefer_constructors_over_static_methods
   static NKUSTHelper get instance {
     return _instance ??= NKUSTHelper();
@@ -182,51 +195,69 @@ class NKUSTHelper {
 
   Future<NotificationsData> getNotifications(int page) async {
     const int pageSize = 15;
+
+    // page 1 is both the initial load and pull-to-refresh — always
+    // refetch. Later pages (infinite scroll) reuse the cached list
+    // unless it has gone stale.
+    final bool stale = _acadCache == null ||
+        _acadCachedAt == null ||
+        DateTime.now().difference(_acadCachedAt!) > _acadCacheTtl;
+    final List<Map<String, dynamic>> all;
+    if (page > 1 && !stale) {
+      all = _acadCache!;
+    } else {
+      all = await _fetchAcadNotifications();
+      _acadCache = all;
+      _acadCachedAt = DateTime.now();
+    }
+
+    final int start = (page - 1) * pageSize;
+    final List<Map<String, dynamic>> acadData = start >= all.length
+        ? <Map<String, dynamic>>[]
+        : all.sublist(
+            start,
+            start + pageSize > all.length ? all.length : start + pageSize,
+          );
+    return NotificationsData.fromJson(<String, dynamic>{
+      'data': <String, dynamic>{
+        'page': page + 1,
+        'notification': acadData,
+      },
+    });
+  }
+
+  /// Fetches, parses and dedups the whole acad announcement list. The
+  /// endpoint 302s for `Page >= 2` and returns everything for `Page 0`.
+  Future<List<Map<String, dynamic>>> _fetchAcadNotifications() async {
     const int maxRetries = 3;
     for (int attempt = 0; attempt <= maxRetries; attempt++) {
       final Response<String> res = await dio.post<String>(
         'https://acad.nkust.edu.tw/app/index.php?Action=mobilercglist',
         data: <String, dynamic>{
-          'Rcg': 2072,
+          'Rcg': _acadRcg,
           'Op': 'getpartlist',
-          // The revamped endpoint only serves Page 0 (Page >= 2 now 302s)
-          // and returns the whole list, so always ask for 0 and window
-          // the result below.
           'Page': 0,
         },
         options:
             Options(contentType: Headers.formUrlEncodedContentType, headers: {
-          'Referer':
-              'https://acad.nkust.edu.tw/p/403-1063-2072-1.php?Lang=zh-tw'
+          'Referer': 'https://acad.nkust.edu.tw/p/403-1063-'
+              '$_acadRcg-1.php?Lang=zh-tw',
         }),
       );
       if (res.statusCode == 200 && res.data != null) {
-        // The revamped endpoint returns the whole list in one shot (and
-        // 302s for Page >= 2), so parse it all, drop any repeated link,
-        // then slice the requested window client-side.
         final List<Map<String, dynamic>> parsed = acadParser(
           html: (json.decode(res.data!) as Map<String, dynamic>)['content']
               as String,
           baseIndex: 0,
         );
         final Set<String> seen = <String>{};
-        final List<Map<String, dynamic>> all = <Map<String, dynamic>>[
+        return <Map<String, dynamic>>[
           for (final Map<String, dynamic> n in parsed)
-            if (seen.add('${n['link']}')) n,
+            if (n['link'] != null &&
+                '${n['link']}'.isNotEmpty &&
+                seen.add('${n['link']}'))
+              n,
         ];
-        final int start = (page - 1) * pageSize;
-        final List<Map<String, dynamic>> acadData = start >= all.length
-            ? <Map<String, dynamic>>[]
-            : all.sublist(
-                start,
-                start + pageSize > all.length ? all.length : start + pageSize,
-              );
-        return NotificationsData.fromJson(<String, dynamic>{
-          'data': <String, dynamic>{
-            'page': page + 1,
-            'notification': acadData,
-          },
-        });
       }
     }
     throw ServerException(

--- a/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
+++ b/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
@@ -181,28 +181,46 @@ class NKUSTHelper {
   }
 
   Future<NotificationsData> getNotifications(int page) async {
-    final int baseIndex = (page - 1) * 15;
+    const int pageSize = 15;
     const int maxRetries = 3;
     for (int attempt = 0; attempt <= maxRetries; attempt++) {
       final Response<String> res = await dio.post<String>(
         'https://acad.nkust.edu.tw/app/index.php?Action=mobilercglist',
         data: <String, dynamic>{
-          'Rcg': 232,
+          'Rcg': 2072,
           'Op': 'getpartlist',
-          'Page': page - 1,
+          // The revamped endpoint only serves Page 0 (Page >= 2 now 302s)
+          // and returns the whole list, so always ask for 0 and window
+          // the result below.
+          'Page': 0,
         },
         options:
             Options(contentType: Headers.formUrlEncodedContentType, headers: {
           'Referer':
-              'https://acad.nkust.edu.tw/p/403-1004-232-1.php?Lang=zh-tw'
+              'https://acad.nkust.edu.tw/p/403-1063-2072-1.php?Lang=zh-tw'
         }),
       );
       if (res.statusCode == 200 && res.data != null) {
-        final List<Map<String, dynamic>> acadData = acadParser(
+        // The revamped endpoint returns the whole list in one shot (and
+        // 302s for Page >= 2), so parse it all, drop any repeated link,
+        // then slice the requested window client-side.
+        final List<Map<String, dynamic>> parsed = acadParser(
           html: (json.decode(res.data!) as Map<String, dynamic>)['content']
               as String,
-          baseIndex: baseIndex,
+          baseIndex: 0,
         );
+        final Set<String> seen = <String>{};
+        final List<Map<String, dynamic>> all = <Map<String, dynamic>>[
+          for (final Map<String, dynamic> n in parsed)
+            if (seen.add('${n['link']}')) n,
+        ];
+        final int start = (page - 1) * pageSize;
+        final List<Map<String, dynamic>> acadData = start >= all.length
+            ? <Map<String, dynamic>>[]
+            : all.sublist(
+                start,
+                start + pageSize > all.length ? all.length : start + pageSize,
+              );
         return NotificationsData.fromJson(<String, dynamic>{
           'data': <String, dynamic>{
             'page': page + 1,

--- a/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
+++ b/packages/nkust_crawler/lib/src/helpers/nkust_helper.dart
@@ -245,11 +245,15 @@ class NKUSTHelper {
         }),
       );
       if (res.statusCode == 200 && res.data != null) {
-        final List<Map<String, dynamic>> parsed = acadParser(
-          html: (json.decode(res.data!) as Map<String, dynamic>)['content']
-              as String,
-          baseIndex: 0,
-        );
+        final String? content = _acadContent(res.data!);
+        if (content == null) {
+          // 200 but the body wasn't the expected `{"content": "..."}`
+          // JSON (e.g. an HTML error page): retry, then give up with a
+          // clean ServerException the UI layer already handles.
+          continue;
+        }
+        final List<Map<String, dynamic>> parsed =
+            acadParser(html: content, baseIndex: 0);
         final Set<String> seen = <String>{};
         return <Map<String, dynamic>>[
           for (final Map<String, dynamic> n in parsed)
@@ -263,5 +267,20 @@ class NKUSTHelper {
     throw ServerException(
       message: 'notifications request returned no usable response',
     );
+  }
+
+  /// Pulls the HTML fragment out of acad's `{"content": "..."}` reply,
+  /// or null if the body isn't that shape (rather than letting a raw
+  /// FormatException escape past the UI's `ApException` handler).
+  static String? _acadContent(String body) {
+    try {
+      final Object? decoded = json.decode(body);
+      if (decoded is Map<String, dynamic> && decoded['content'] is String) {
+        return decoded['content'] as String;
+      }
+    } on FormatException {
+      // fall through
+    }
+    return null;
   }
 }

--- a/packages/nkust_crawler/lib/src/parsers/nkust_parser.dart
+++ b/packages/nkust_crawler/lib/src/parsers/nkust_parser.dart
@@ -2,6 +2,10 @@
 import 'package:html/dom.dart';
 import 'package:html/parser.dart' show parse;
 
+/// Whitespace-tolerant match for the `%置頂%` pin marker the acad list
+/// appends to a title's text.
+final RegExp _pinnedMarker = RegExp(r'%\s*置頂\s*%');
+
 List<Map<String, dynamic>> acadParser({
   required String? html,
   required int baseIndex,
@@ -17,16 +21,23 @@ List<Map<String, dynamic>> acadParser({
     if (dTxtList.isNotEmpty) {
       // The revamped acad list wraps the title link in its own `.d-txt`,
       // so a row now has [date, title, department]; the plain list keeps
-      // [date, department]. Reading first/last is correct for both.
+      // [date, department]. `first`/`last` is correct for both, but they
+      // collapse to the same element when a row only carries one, so
+      // only fill `department` when there are genuinely two or more.
       info['date'] = _clean(dTxtList.first.text);
-      info['department'] = _clean(dTxtList.last.text);
+      info['department'] =
+          dTxtList.length >= 2 ? _clean(dTxtList.last.text) : '';
     }
-    if (element.getElementsByTagName('a').isNotEmpty) {
+    final List<Element> anchors = element.getElementsByTagName('a');
+    final String? link =
+        anchors.isEmpty ? null : anchors.first.attributes['href'];
+    if (link != null && link.isNotEmpty) {
       info['index'] = baseIndex;
       baseIndex++;
-      info['title'] =
-          element.getElementsByTagName('a')[0].text.replaceAll('%置頂%', '').trim();
-      temp['link'] = element.getElementsByTagName('a')[0].attributes['href'];
+      final String rawTitle = anchors.first.text.trim();
+      info['pinned'] = _pinnedMarker.hasMatch(rawTitle);
+      info['title'] = rawTitle.replaceAll(_pinnedMarker, '').trim();
+      temp['link'] = link;
       temp['info'] = info;
       dataList.add(temp);
     }

--- a/packages/nkust_crawler/lib/src/parsers/nkust_parser.dart
+++ b/packages/nkust_crawler/lib/src/parsers/nkust_parser.dart
@@ -14,15 +14,18 @@ List<Map<String, dynamic>> acadParser({
     final Map<String, dynamic> temp = <String, dynamic>{};
     final Map<String, dynamic> info = <String, dynamic>{};
     final List<Element> dTxtList = element.getElementsByClassName('d-txt');
-    if (element.getElementsByClassName('d-txt').isNotEmpty) {
-      info['date'] = dTxtList[0].text.replaceAll('	', '').replaceAll('\n', '');
-      info['department'] =
-          dTxtList[1].text.replaceAll('	', '').replaceAll('\n', '');
+    if (dTxtList.isNotEmpty) {
+      // The revamped acad list wraps the title link in its own `.d-txt`,
+      // so a row now has [date, title, department]; the plain list keeps
+      // [date, department]. Reading first/last is correct for both.
+      info['date'] = _clean(dTxtList.first.text);
+      info['department'] = _clean(dTxtList.last.text);
     }
     if (element.getElementsByTagName('a').isNotEmpty) {
       info['index'] = baseIndex;
       baseIndex++;
-      info['title'] = element.getElementsByTagName('a')[0].text.trim();
+      info['title'] =
+          element.getElementsByTagName('a')[0].text.replaceAll('%置頂%', '').trim();
       temp['link'] = element.getElementsByTagName('a')[0].attributes['href'];
       temp['info'] = info;
       dataList.add(temp);
@@ -30,3 +33,6 @@ List<Map<String, dynamic>> acadParser({
   }
   return dataList;
 }
+
+String _clean(String raw) =>
+    raw.replaceAll('	', '').replaceAll('\n', '').trim();

--- a/packages/nkust_crawler/test/acad_parser_test.dart
+++ b/packages/nkust_crawler/test/acad_parser_test.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+
+import 'package:nkust_crawler/src/parsers/nkust_parser.dart';
+import 'package:test/test.dart';
+
+String _fixture(String name) =>
+    File('test/fixtures/$name').readAsStringSync();
+
+void main() {
+  group('acadParser — pre-revamp layout [date, department]', () {
+    late final List<Map<String, dynamic>> rows =
+        acadParser(html: _fixture('acad_old.html'), baseIndex: 0);
+
+    test('reads date, department, title and link', () {
+      expect(rows, hasLength(2));
+      expect(rows[0]['info']['date'], '2024/03/15');
+      expect(rows[0]['info']['department'], '教務處');
+      expect(rows[0]['info']['title'], '113學年度第二學期選課公告');
+      expect(rows[0]['link'], '/news/001');
+      expect(rows[1]['info']['department'], '學務處');
+      expect(rows[1]['link'], '/news/002');
+    });
+
+    test('numbers rows from baseIndex', () {
+      final List<Map<String, dynamic>> shifted =
+          acadParser(html: _fixture('acad_old.html'), baseIndex: 10);
+      expect(shifted[0]['info']['index'], 10);
+      expect(shifted[1]['info']['index'], 11);
+    });
+  });
+
+  group('acadParser — revamped layout [date, title, department]', () {
+    late final List<Map<String, dynamic>> rows =
+        acadParser(html: _fixture('acad_new.html'), baseIndex: 0);
+
+    test('department comes from the last cell, not the title', () {
+      expect(rows, hasLength(2));
+      expect(rows[0]['info']['department'], '課務組');
+      expect(
+        rows[0]['info']['title'],
+        isNot(contains('課務組')),
+      );
+    });
+
+    test('trims the padded date', () {
+      expect(rows[0]['info']['date'], '2026-05-21');
+    });
+
+    test('strips the %置頂% marker and records pinned state', () {
+      expect(rows[0]['info']['title'],
+          '【選課訊息】115-1學期各學制初選、加退選重要通知，請查照。');
+      expect(rows[0]['info']['pinned'], isTrue);
+      expect(rows[1]['info']['pinned'], isFalse);
+    });
+
+    test('drops a row whose <a> has no usable href', () {
+      // acad_new.html has a third <tr> with `<a href="">` — it must not
+      // appear (a link-less notification is unopenable and its empty
+      // href would also collapse dedup keys downstream).
+      expect(
+        rows.every(
+          (Map<String, dynamic> r) => (r['link'] as String).isNotEmpty,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  test('a row with a single .d-txt leaves department empty, not the date',
+      () {
+    const String html = '''
+      <table><tr>
+        <td><div class="d-txt">2026-09-01</div></td>
+        <td><a href="/x">only one cell</a></td>
+      </tr></table>
+    ''';
+    final List<Map<String, dynamic>> rows =
+        acadParser(html: html, baseIndex: 0);
+    expect(rows, hasLength(1));
+    expect(rows[0]['info']['date'], '2026-09-01');
+    expect(rows[0]['info']['department'], '');
+  });
+}

--- a/packages/nkust_crawler/test/fixtures/acad_new.html
+++ b/packages/nkust_crawler/test/fixtures/acad_new.html
@@ -1,0 +1,23 @@
+<html><body>
+<table class="listTB table">
+<tbody>
+  <tr>
+    <td data-th="日期"><div class="d-txt">
+					2026-05-21 </div></td>
+    <td data-th="標題"><div class="d-txt"><div class="mtitle"><a title="" href="https://acad.nkust.edu.tw/p/406-1063-105545,r2072.php?Lang=zh-tw">
+					【選課訊息】115-1學期各學制初選、加退選重要通知，請查照。 %置頂%</a></div></div></td>
+    <td data-th="資料建立者"><div class="d-txt">
+					課務組</div></td>
+  </tr>
+  <tr>
+    <td data-th="日期"><div class="d-txt">2026-08-31</div></td>
+    <td data-th="標題"><div class="d-txt"><div class="mtitle"><a href="https://acad.nkust.edu.tw/p/406-1063-105282,r2072.php?Lang=zh-tw">【課程查詢】115-1學期開設課程資訊查詢方式說明</a></div></div></td>
+    <td data-th="資料建立者"><div class="d-txt">課務組</div></td>
+  </tr>
+  <tr>
+    <td data-th="標題"><div class="d-txt"><a href="">壞掉的列，沒有連結</a></div></td>
+    <td data-th="資料建立者"><div class="d-txt">課務組</div></td>
+  </tr>
+</tbody>
+</table>
+</body></html>

--- a/packages/nkust_crawler/test/fixtures/acad_old.html
+++ b/packages/nkust_crawler/test/fixtures/acad_old.html
@@ -1,0 +1,18 @@
+<html><body>
+<table>
+  <tr>
+    <td>
+      <span class="d-txt">2024/03/15</span>
+      <span class="d-txt">教務處</span>
+      <a href="/news/001" title="113學年度第二學期選課公告">113學年度第二學期選課公告</a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <span class="d-txt">2024/03/10</span>
+      <span class="d-txt">學務處</span>
+      <a href="/news/002" title="校園防疫措施公告">校園防疫措施公告</a>
+    </td>
+  </tr>
+</table>
+</body></html>

--- a/packages/nkust_crawler/test/live/notifications_live_test.dart
+++ b/packages/nkust_crawler/test/live/notifications_live_test.dart
@@ -22,7 +22,7 @@ void main() {
   test(
     'getNotifications page 1 returns at least one announcement',
     () async {
-      print('[live] POST acad.nkust.edu.tw  Rcg=232  Page=0');
+      print('[live] POST acad.nkust.edu.tw  Rcg=2072  page 1');
       final NotificationsData result =
           await NKUSTHelper.instance.getNotifications(1);
 

--- a/packages/nkust_crawler/test/live/notifications_live_test.dart
+++ b/packages/nkust_crawler/test/live/notifications_live_test.dart
@@ -41,4 +41,28 @@ void main() {
     },
     timeout: const Timeout(Duration(seconds: 30)),
   );
+
+  test(
+    'page 2 returns a non-overlapping window without erroring',
+    () async {
+      // The reported bug was "scroll past ~30 items -> 學校伺服器錯誤",
+      // i.e. page >= 2 (which the endpoint now 302s for). Page 1 alone
+      // never caught it.
+      final NotificationsData p1 =
+          await NKUSTHelper.instance.getNotifications(1);
+      final NotificationsData p2 =
+          await NKUSTHelper.instance.getNotifications(2);
+      print('[live]   page1=${p1.data.notifications.length} '
+          'page2=${p2.data.notifications.length}');
+
+      expect(p2.data.notifications, isNotEmpty);
+
+      final Set<String?> links1 =
+          p1.data.notifications.map((Notifications n) => n.link).toSet();
+      final Set<String?> links2 =
+          p2.data.notifications.map((Notifications n) => n.link).toSet();
+      expect(links1.intersection(links2), isEmpty);
+    },
+    timeout: const Timeout(Duration(seconds: 30)),
+  );
 }

--- a/packages/nkust_crawler/test/notifications_cache_test.dart
+++ b/packages/nkust_crawler/test/notifications_cache_test.dart
@@ -9,6 +9,11 @@ import 'package:test/test.dart';
 /// Answers the acad `mobilercglist` POST with a canned list and counts
 /// how many times it's actually hit.
 class _AcadAdapter implements HttpClientAdapter {
+  _AcadAdapter({this.body});
+
+  /// Overrides the response body; when null a valid `{"content": ...}`
+  /// payload with 40 rows is returned.
+  final String? body;
   int posts = 0;
 
   static String _rows(int n) {
@@ -37,7 +42,7 @@ class _AcadAdapter implements HttpClientAdapter {
     if (options.uri.toString().contains('mobilercglist')) {
       posts++;
       return ResponseBody.fromString(
-        jsonEncode(<String, dynamic>{'content': _rows(40)}),
+        body ?? jsonEncode(<String, dynamic>{'content': _rows(40)}),
         200,
       );
     }
@@ -94,5 +99,19 @@ void main() {
     await helper.getNotifications(1);
     final NotificationsData far = await helper.getNotifications(99);
     expect(far.data.notifications, isEmpty);
+  });
+
+  test('a 200 with a non-JSON body fails cleanly, not with FormatException',
+      () async {
+    final _AcadAdapter adapter =
+        _AcadAdapter(body: '<html><body>502 Bad Gateway</body></html>');
+    final NKUSTHelper helper = newHelper(adapter);
+
+    await expectLater(
+      helper.getNotifications(1),
+      throwsA(isA<ServerException>()),
+    );
+    // retried before giving up
+    expect(adapter.posts, greaterThan(1));
   });
 }

--- a/packages/nkust_crawler/test/notifications_cache_test.dart
+++ b/packages/nkust_crawler/test/notifications_cache_test.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:ap_common_core/ap_common_core.dart';
+import 'package:dio/dio.dart';
+import 'package:nkust_crawler/nkust_crawler.dart';
+import 'package:test/test.dart';
+
+/// Answers the acad `mobilercglist` POST with a canned list and counts
+/// how many times it's actually hit.
+class _AcadAdapter implements HttpClientAdapter {
+  int posts = 0;
+
+  static String _rows(int n) {
+    final StringBuffer b = StringBuffer('<table class="listTB table"><tbody>');
+    for (int i = 0; i < n; i++) {
+      b.write(
+        '<tr>'
+        '<td data-th="日期"><div class="d-txt">2026-09-${i + 1} </div></td>'
+        '<td data-th="標題"><div class="d-txt"><div class="mtitle">'
+        '<a href="https://acad.nkust.edu.tw/p/406-1063-$i,r2072.php">'
+        '公告 $i</a></div></div></td>'
+        '<td data-th="資料建立者"><div class="d-txt">課務組</div></td>'
+        '</tr>',
+      );
+    }
+    b.write('</tbody></table>');
+    return b.toString();
+  }
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.uri.toString().contains('mobilercglist')) {
+      posts++;
+      return ResponseBody.fromString(
+        jsonEncode(<String, dynamic>{'content': _rows(40)}),
+        200,
+      );
+    }
+    return ResponseBody.fromString('', 404);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+void main() {
+  NKUSTHelper newHelper(_AcadAdapter adapter) {
+    final NKUSTHelper helper = NKUSTHelper();
+    helper.dio = Dio(BaseOptions(responseType: ResponseType.plain))
+      ..httpClientAdapter = adapter;
+    return helper;
+  }
+
+  test('scrolling to later pages reuses one fetch of the full list', () async {
+    final _AcadAdapter adapter = _AcadAdapter();
+    final NKUSTHelper helper = newHelper(adapter);
+
+    final NotificationsData p1 = await helper.getNotifications(1);
+    final NotificationsData p2 = await helper.getNotifications(2);
+    final NotificationsData p3 = await helper.getNotifications(3);
+
+    expect(adapter.posts, 1);
+    expect(p1.data.notifications, hasLength(15));
+    expect(p2.data.notifications, hasLength(15));
+    expect(p3.data.notifications, hasLength(10));
+
+    final Set<String?> l1 =
+        p1.data.notifications.map((Notifications n) => n.link).toSet();
+    final Set<String?> l2 =
+        p2.data.notifications.map((Notifications n) => n.link).toSet();
+    expect(l1.intersection(l2), isEmpty);
+  });
+
+  test('page 1 always refetches (initial load / pull-to-refresh)', () async {
+    final _AcadAdapter adapter = _AcadAdapter();
+    final NKUSTHelper helper = newHelper(adapter);
+
+    await helper.getNotifications(1);
+    await helper.getNotifications(2);
+    await helper.getNotifications(1);
+
+    expect(adapter.posts, 2);
+  });
+
+  test('past the end returns an empty window, no error', () async {
+    final _AcadAdapter adapter = _AcadAdapter();
+    final NKUSTHelper helper = newHelper(adapter);
+
+    await helper.getNotifications(1);
+    final NotificationsData far = await helper.getNotifications(99);
+    expect(far.data.notifications, isEmpty);
+  });
+}


### PR DESCRIPTION
修正爬蟲結構異常問題，確保能正確抓取校園資訊

## 問題

`acad.nkust.edu.tw` 改版後，教務處公告（`getNotifications`）失效：

- 公告分類 ID 換了（`Rcg` `232` → `2072`），舊 ID 已 404，導致列表回空。
- 不再做 server 端分頁：`Page 0` 直接回整包，`Page >= 2` 會 302；使用者往下滑超過 ~30 筆時就跳「學校伺服器錯誤」。
- 列表每列的標題連結被包進自己的 `.d-txt`，`acadParser` 把標題誤當成公告單位。

## 修正

- `Rcg` 改 `2072`、Referer 換新列表頁。
- 固定請求 `Page 0`，取回整包後 client 端切 15 筆的視窗；超過尾端回空陣列，讓無限捲動自然停止。
- 依 link 去重。
- `acadParser` 改讀 `.d-txt` 的 `first` / `last`（相容新舊結構）、trim 空白、標題去掉 `%置頂%` 標記。